### PR TITLE
feat/improved-import-time-by-external-separation

### DIFF
--- a/developer/README.md
+++ b/developer/README.md
@@ -71,3 +71,17 @@ For pre-commit run the following command:
 ```bash
     uv run pre-commit run --all-files
 ```
+
+To perform profiling, we use `tuna`
+
+1. Run the following command to the script you want to profile:
+
+```bash
+    uv run python -X importtime profile.py 2> import.log
+```
+
+2. Run the following command for visualization:
+
+```bash
+    uvx tuna import.log
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "pytest>=8.3.3",
     "seaborn>=0.13.2",
     "treescope>=0.1.6",
+    "tune>=0.1.6",
 ]
 
 [tool.pyright]

--- a/src/inspeqtor/experimental/__init__.py
+++ b/src/inspeqtor/experimental/__init__.py
@@ -1,7 +1,6 @@
 from . import (
     data as data,
     pulse as pulse,
-    qiskit as qiskit,
     typing as typing,
     utils as utils,
     constant as constant,

--- a/src/inspeqtor/experimental/optimize.py
+++ b/src/inspeqtor/experimental/optimize.py
@@ -7,11 +7,13 @@ from dataclasses import dataclass
 import flax.traverse_util as traverse_util
 from functools import partial
 import optax
-from ray import tune, train
+
+# from ray import tune, train
 import tempfile
-from ray.tune.search.hyperopt import HyperOptSearch
-from ray.tune.search.optuna import OptunaSearch
-from ray.tune.search import Searcher
+
+# from ray.tune.search.hyperopt import HyperOptSearch
+# from ray.tune.search.optuna import OptunaSearch
+# from ray.tune.search import Searcher
 from enum import StrEnum
 
 from .pulse import PulseSequence
@@ -182,6 +184,8 @@ def default_trainable_v3(
     NUM_EPOCH: int = 1000,
     CHECKPOINT_EVERY: int = 100,
 ):
+    from ray import train
+
     def trainable(
         config: dict[str, int],
         pulse_parameters: jnp.ndarray,
@@ -306,6 +310,11 @@ def hypertuner(
     num_samples: int = 100,
     search_algo: SearchAlgo = SearchAlgo.HYPEROPT,
 ):
+    from ray import tune, train
+    from ray.tune.search.hyperopt import HyperOptSearch
+    from ray.tune.search.optuna import OptunaSearch
+    from ray.tune.search import Searcher
+
     search_space = {
         "hidden_layer_1_1": tune.randint(5, 50),
         "hidden_layer_1_2": tune.randint(5, 50),

--- a/src/inspeqtor/experimental/physics.py
+++ b/src/inspeqtor/experimental/physics.py
@@ -1,31 +1,29 @@
 from flax import struct
 import jax
 import jax.numpy as jnp
-import numpy as np
 import typing
 from dataclasses import dataclass
 from enum import Enum
 import diffrax  # type: ignore
 from .typing import ParametersDictType
-from .qiskit import IBMQDeviceProperties
-from .data import QubitInformation, ExpectationValue
+from .data import QubitInformation
 from .constant import X, Y, Z
 from .pulse import PulseSequence
 
-# Forest-Benchmarking
-from forest.benchmarking.observable_estimation import (  # type: ignore
-    ExperimentResult,
-    ExperimentSetting,
-    TensorProductState,
-    PauliTerm,
-)
-from forest.benchmarking.tomography import (  # type: ignore
-    linear_inv_process_estimate,
-    pgdb_process_estimate,
-)
-from forest.benchmarking.operator_tools.superoperator_transformations import (  # type: ignore
-    choi2superop,
-)
+# # Forest-Benchmarking
+# from forest.benchmarking.observable_estimation import (  # type: ignore
+#     ExperimentResult,
+#     ExperimentSetting,
+#     TensorProductState,
+#     PauliTerm,
+# )
+# from forest.benchmarking.tomography import (  # type: ignore
+#     linear_inv_process_estimate,
+#     pgdb_process_estimate,
+# )
+# from forest.benchmarking.operator_tools.superoperator_transformations import (  # type: ignore
+#     choi2superop,
+# )
 
 
 @struct.dataclass
@@ -235,35 +233,6 @@ def tensor(operator: jnp.ndarray, position: int, total_qubits: int):
     )
 
 
-def get_coupling_strengths(
-    backend_properties: IBMQDeviceProperties,
-) -> list[CouplingInformation]:
-    # https://qiskit-extensions.github.io/qiskit-dynamics/stubs/qiskit_dynamics.backend.parse_backend_hamiltonian_dict.html
-    # Get the qubits coupling map
-    qubit_idxs = [qubit.qubit_idx for qubit in backend_properties.qubit_informations]
-    # Get the edges of the coupling map
-    edge_reindex = list(
-        backend_properties.backend_instance.coupling_map.reduce(qubit_idxs).get_edges()
-    )
-    # Map the edges to the qubit indices
-    edges = [(qubit_idxs[edge[0]], qubit_idxs[edge[1]]) for edge in edge_reindex]
-    # Get the coupling constants
-    coupling_constants: list[CouplingInformation] = []
-    for i, j in edges:
-        # Get the coupling constant
-        coupling_const = backend_properties.hamiltonian_data["vars"].get(
-            f"jq{i}q{j}", 0
-        )
-        # Add the coupling constant to the list
-        coupling_constants.append(
-            CouplingInformation(
-                qubit_indices=(i, j),
-                coupling_strength=coupling_const / (2 * jnp.pi),
-            )
-        )
-    return coupling_constants
-
-
 def gen_hamiltonian_from(
     qubit_informations: list[QubitInformation],
     coupling_constants: list[CouplingInformation],
@@ -459,103 +428,6 @@ def check_valid_density_matrix(rho: jnp.ndarray):
 
 def check_hermitian(op: jnp.ndarray):
     assert jnp.allclose(op, op.conj().T), "Matrix is not Hermitian"
-
-
-def process_tomography(
-    rho_0: jnp.ndarray,
-    rho_1: jnp.ndarray,
-    rho_p: jnp.ndarray,
-    rho_m: jnp.ndarray,
-):
-    Lambda = (1 / 2) * jnp.block([[jnp.eye(2), X], [X, -jnp.eye(2)]])
-
-    rho_p1 = rho_0
-    rho_p4 = rho_1
-    rho_p2 = rho_p - 1j * rho_m - (1 - 1j) * (rho_p1 + rho_p4) / 2
-    rho_p3 = rho_p + 1j * rho_m - (1 + 1j) * (rho_p1 + rho_p4) / 2
-
-    # NOTE: This is difference from the block 8.5 in Nielsen and Chuang.
-    Rho = jnp.block([[rho_p1, rho_p3], [rho_p2, rho_p4]])
-    # Rho = jnp.block([[rho_p1, rho_p2], [rho_p3, rho_p4]])
-
-    # return choi2superop(Rho)
-
-    Chi = Lambda @ Rho @ Lambda
-
-    # Check hermitain
-    check_hermitian(Chi)
-
-    # From process matrix to choi matrix
-    P_0 = jnp.eye(2)
-    P_1 = X
-    # P_2 = -1*Y
-    P_2 = Y
-    P_3 = Z
-
-    Ps = [P_0, P_1, P_2, P_3]
-    choi_matrix = jnp.zeros((4, 4))
-    for m, pauli_m in enumerate(Ps):
-        for n, pauli_n in enumerate(Ps):
-            superket_m = pauli_m.flatten().reshape(-1, 1)
-            superbra_n = pauli_n.flatten().conj()
-            # Outer product
-            choi_basis = Chi[m, n] * jnp.outer(superket_m, superbra_n)
-            choi_matrix += choi_basis
-
-    return jnp.array(choi2superop(np.array(choi_matrix)))
-
-
-initial_state_mapping = {
-    "0": "Z+",
-    "1": "Z-",
-    "+": "X+",
-    "-": "X-",
-    "r": "Y+",
-    "l": "Y-",
-}
-
-
-def forest_process_tomography(
-    expvals: list[ExpectationValue],
-    is_linear_inv: bool = True,
-):
-    """Calculate the process tomography estimate using the Forest-benchmarking library.
-
-    Args:
-        expvals (list[sq.data.ExpectationValue]): The list of expectation values.
-
-    Returns:
-        _type_: The process tomography estimate in the Choi matrix representation.
-    """
-    # Extract results
-    exp_results = []
-
-    for expval in expvals:
-        assert isinstance(
-            expval.expectation_value, float
-        ), "Expectation value is not float"
-
-        exp_results.append(
-            ExperimentResult(
-                setting=ExperimentSetting(
-                    observable=PauliTerm.from_list(
-                        [(expval.observable, 0)]
-                    ),  # NOTE: Assumes qubit 0
-                    in_state=TensorProductState.from_str(
-                        f"{initial_state_mapping[expval.initial_state]}_0"  # NOTE: Assumes qubit 0
-                    ),
-                ),
-                expectation=expval.expectation_value,
-                total_counts=1000,  # TODO: Should be set to the actual number of counts?
-            )
-        )
-
-    if is_linear_inv:
-        est = linear_inv_process_estimate(exp_results, [0])  # NOTE: Assumes qubit 0
-    else:
-        est = pgdb_process_estimate(exp_results, [0])  # NOTE: Assumes qubit 0
-
-    return est
 
 
 def direct_AFG_estimation(

--- a/src/inspeqtor/external/benchmarking.py
+++ b/src/inspeqtor/external/benchmarking.py
@@ -1,0 +1,116 @@
+import jax.numpy as jnp
+import numpy as np
+
+from ..experimental.physics import check_hermitian, X, Y, Z
+from ..experimental.data import ExpectationValue
+
+from forest.benchmarking.observable_estimation import (  # type: ignore
+    ExperimentResult,
+    ExperimentSetting,
+    TensorProductState,
+    PauliTerm,
+)
+from forest.benchmarking.tomography import (  # type: ignore
+    linear_inv_process_estimate,
+    pgdb_process_estimate,
+)
+from forest.benchmarking.operator_tools.superoperator_transformations import (  # type: ignore
+    choi2superop,
+)
+
+
+initial_state_mapping = {
+    "0": "Z+",
+    "1": "Z-",
+    "+": "X+",
+    "-": "X-",
+    "r": "Y+",
+    "l": "Y-",
+}
+
+
+def process_tomography(
+    rho_0: jnp.ndarray,
+    rho_1: jnp.ndarray,
+    rho_p: jnp.ndarray,
+    rho_m: jnp.ndarray,
+):
+    Lambda = (1 / 2) * jnp.block([[jnp.eye(2), X], [X, -jnp.eye(2)]])
+
+    rho_p1 = rho_0
+    rho_p4 = rho_1
+    rho_p2 = rho_p - 1j * rho_m - (1 - 1j) * (rho_p1 + rho_p4) / 2
+    rho_p3 = rho_p + 1j * rho_m - (1 + 1j) * (rho_p1 + rho_p4) / 2
+
+    # NOTE: This is difference from the block 8.5 in Nielsen and Chuang.
+    Rho = jnp.block([[rho_p1, rho_p3], [rho_p2, rho_p4]])
+    # Rho = jnp.block([[rho_p1, rho_p2], [rho_p3, rho_p4]])
+
+    # return choi2superop(Rho)
+
+    Chi = Lambda @ Rho @ Lambda
+
+    # Check hermitain
+    check_hermitian(Chi)
+
+    # From process matrix to choi matrix
+    P_0 = jnp.eye(2)
+    P_1 = X
+    # P_2 = -1*Y
+    P_2 = Y
+    P_3 = Z
+
+    Ps = [P_0, P_1, P_2, P_3]
+    choi_matrix = jnp.zeros((4, 4))
+    for m, pauli_m in enumerate(Ps):
+        for n, pauli_n in enumerate(Ps):
+            superket_m = pauli_m.flatten().reshape(-1, 1)
+            superbra_n = pauli_n.flatten().conj()
+            # Outer product
+            choi_basis = Chi[m, n] * jnp.outer(superket_m, superbra_n)
+            choi_matrix += choi_basis
+
+    return jnp.array(choi2superop(np.array(choi_matrix)))
+
+
+def forest_process_tomography(
+    expvals: list[ExpectationValue],
+    is_linear_inv: bool = True,
+):
+    """Calculate the process tomography estimate using the Forest-benchmarking library.
+
+    Args:
+        expvals (list[sq.data.ExpectationValue]): The list of expectation values.
+
+    Returns:
+        _type_: The process tomography estimate in the Choi matrix representation.
+    """
+    # Extract results
+    exp_results = []
+
+    for expval in expvals:
+        assert isinstance(
+            expval.expectation_value, float
+        ), "Expectation value is not float"
+
+        exp_results.append(
+            ExperimentResult(
+                setting=ExperimentSetting(
+                    observable=PauliTerm.from_list(
+                        [(expval.observable, 0)]
+                    ),  # NOTE: Assumes qubit 0
+                    in_state=TensorProductState.from_str(
+                        f"{initial_state_mapping[expval.initial_state]}_0"  # NOTE: Assumes qubit 0
+                    ),
+                ),
+                expectation=expval.expectation_value,
+                total_counts=1000,  # TODO: Should be set to the actual number of counts?
+            )
+        )
+
+    if is_linear_inv:
+        est = linear_inv_process_estimate(exp_results, [0])  # NOTE: Assumes qubit 0
+    else:
+        est = pgdb_process_estimate(exp_results, [0])  # NOTE: Assumes qubit 0
+
+    return est

--- a/src/inspeqtor/legacy/data.py
+++ b/src/inspeqtor/legacy/data.py
@@ -7,10 +7,7 @@ import typing
 import json
 import numpy as np
 from pathlib import Path
-import torch
-from torch import Generator
-import torch.utils
-from torch.utils.data import DataLoader, Dataset, random_split
+from torch.utils.data import DataLoader, Dataset
 from .typing import ParametersDictType
 import pandas as pd  # type: ignore
 import logging
@@ -726,6 +723,8 @@ class SpecQDataset(Dataset):
         unitaries: np.ndarray,
         expectation_values: np.ndarray,
     ):
+        import torch
+
         self.pulse_parameters = torch.from_numpy(pulse_parameters)
         self.unitaries = torch.from_numpy(unitaries)
         self.expectation_values = torch.from_numpy(expectation_values)
@@ -751,6 +750,9 @@ def prepare_dataset(
     batch_size_ratio: float = 0.1,
     ratio: list[float] = [0.8, 0.1, 0.1],
 ) -> tuple[DataLoader, DataLoader, typing.Union[DataLoader, None]]:
+    from torch import Generator
+    from torch.utils.data import DataLoader, random_split
+
     # Sanity check on the inputs
     # pulse_parameters.shape should be len(shape) == 2
     assert (

--- a/tests/experimental/test_physics.py
+++ b/tests/experimental/test_physics.py
@@ -6,6 +6,7 @@ from qiskit_ibm_runtime.fake_provider import FakeJakartaV2  # type: ignore
 import qiskit.quantum_info as qi  # type: ignore
 from forest.benchmarking import operator_tools as ot  # type: ignore
 import inspeqtor.experimental as sq
+from inspeqtor.external import qiskit as qk, benchmarking as bm
 import pennylane as qml  # type: ignore
 from typing import Callable
 import numpy as np
@@ -324,12 +325,12 @@ def test_crosscheck_pennylane_difflax():
 
     # NOTE: Crosscheck with the hamiltonian_fn flow
     backend = FakeJakartaV2()
-    backend_properties = sq.qiskit.IBMQDeviceProperties.from_backend(
+    backend_properties = qk.IBMQDeviceProperties.from_backend(
         backend=backend, qubit_indices=[0]
     )
     backend_properties.qubit_informations = [qubit_info]
 
-    coupling_infos = sq.physics.get_coupling_strengths(backend_properties)
+    coupling_infos = qk.get_coupling_strengths(backend_properties)
 
     total_hamiltonian = sq.physics.gen_hamiltonian_from(
         qubit_informations=backend_properties.qubit_informations,
@@ -455,7 +456,7 @@ def test_process_tomography(gate: jnp.ndarray):
     # Normally, those rho would be retrived from state tomography.
     assert jnp.allclose(
         sq.physics.avg_gate_fidelity_from_superop(
-            sq.physics.process_tomography(rho_0, rho_1, rho_p, rho_m),
+            bm.process_tomography(rho_0, rho_1, rho_p, rho_m),
             sq.physics.to_superop(gate),
         ),
         jnp.array(1.0),
@@ -510,7 +511,7 @@ def test_forest_process_tomography(gate_with_fidelity: list[jnp.ndarray]):
         )
         expvals.append(exp)
 
-    est_superoperator = ot.choi2superop(sq.physics.forest_process_tomography(expvals))
+    est_superoperator = ot.choi2superop(bm.forest_process_tomography(expvals))
 
     assert jnp.allclose(
         sq.physics.avg_gate_fidelity_from_superop(

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,18 @@ wheels = [
 ]
 
 [[package]]
+name = "adagio"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "triad" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/d7/c02a080407e133cf404a2b63bb3de1495c65d7af0501c313731a545d39ca/adagio-0.2.6.tar.gz", hash = "sha256:0c32768f3aba0e05273b36f9420a482034f2510f059171040d7e98ba34128d7a", size = 23653 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/40/3592ba5232475778ab690cdbfbc38e73886c26c361a82484b49fab427e60/adagio-0.2.6-py3-none-any.whl", hash = "sha256:1bb8317d41bfff8b11373bc03c9859ff166c498214bb2b7ce1e21638c0babb2c", size = 19073 },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -863,12 +875,39 @@ wheels = [
 ]
 
 [[package]]
+name = "fs"
+version = "2.4.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appdirs" },
+    { name = "setuptools" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/a9/af5bfd5a92592c16cdae5c04f68187a309be8a146b528eac3c6e30edbad2/fs-2.4.16.tar.gz", hash = "sha256:ae97c7d51213f4b70b6a958292530289090de3a7e15841e108fbe144f069d313", size = 187441 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/5c/a3d95dc1ec6cdeb032d789b552ecc76effa3557ea9186e1566df6aac18df/fs-2.4.16-py2.py3-none-any.whl", hash = "sha256:660064febbccda264ae0b6bace80a8d1be9e089e0a5eb2427b7d517f9a91545c", size = 135261 },
+]
+
+[[package]]
 name = "fsspec"
 version = "2024.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a0/52/f16a068ebadae42526484c31f4398e62962504e5724a8ba5dc3409483df2/fsspec-2024.10.0.tar.gz", hash = "sha256:eda2d8a4116d4f2429db8550f2457da57279247dd930bb12f821b58391359493", size = 286853 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/b2/454d6e7f0158951d8a78c2e1eb4f69ae81beb8dca5fee9809c6c99e9d0d0/fsspec-2024.10.0-py3-none-any.whl", hash = "sha256:03b9a6785766a4de40368b88906366755e2819e758b83705c88cd7cb5fe81871", size = 179641 },
+]
+
+[[package]]
+name = "fugue"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "adagio" },
+    { name = "triad" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/a1/eca331442c758f8a6f23792dd10a51fb827fad1204805d6c70f02a35ee00/fugue-0.9.1.tar.gz", hash = "sha256:fb0f9a4780147ac8438be96efc50593e2d771d1cbf528ac56d3bcecd39915b50", size = 224340 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/38/46a0ef179f7279207a3263afeb8da4dd73f44d00b6cc999c96a39112d284/fugue-0.9.1-py3-none-any.whl", hash = "sha256:5b91e55e6f243af6e2b901dc37914d954d8f0231627b68007850879f8848a3a3", size = 278186 },
 ]
 
 [[package]]
@@ -1234,6 +1273,7 @@ dev = [
     { name = "pytest" },
     { name = "seaborn" },
     { name = "treescope" },
+    { name = "tune" },
 ]
 
 [package.metadata]
@@ -1269,6 +1309,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "treescope", specifier = ">=0.1.6" },
+    { name = "tune", specifier = ">=0.1.6" },
 ]
 
 [[package]]
@@ -3912,6 +3953,23 @@ wheels = [
 ]
 
 [[package]]
+name = "triad"
+version = "0.9.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fs" },
+    { name = "fsspec" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/28/fca2981080bfb44e317b3fc6cc4119a0abf14f18e707a612764fcad28790/triad-0.9.8.tar.gz", hash = "sha256:5b67673124891981daf8afbab44b2e6358932ca35ef3ff38a25bc3e0f6f03f17", size = 56086 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/c6/4aedce0522bb3c72f2d770e7e4c18b0e1f7716d2c70a865e94c89ebcf7e6/triad-0.9.8-py3-none-any.whl", hash = "sha256:2c0ba7d83977c6d4e7b59e3cc70727f858014ef7676c62d184aa8e63f7bef5de", size = 62340 },
+]
+
+[[package]]
 name = "triton"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3921,6 +3979,21 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/17/d9a5cf4fcf46291856d1e90762e36cbabd2a56c7265da0d1d9508c8e3943/triton-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f34f6e7885d1bf0eaaf7ba875a5f0ce6f3c13ba98f9503651c1e6dc6757ed5c", size = 209506424 },
     { url = "https://files.pythonhosted.org/packages/78/eb/65f5ba83c2a123f6498a3097746607e5b2f16add29e36765305e4ac7fdd8/triton-3.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8182f42fd8080a7d39d666814fa36c5e30cc00ea7eeeb1a2983dbb4c99a0fdc", size = 209551444 },
+]
+
+[[package]]
+name = "tune"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "fs" },
+    { name = "fugue" },
+    { name = "triad" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/38/329febab4b0e071e252a8210e12d9415dd47a9793018770970e96d3282d7/tune-0.1.6.tar.gz", hash = "sha256:6de79adf3ccfb416989839d0407730b8c2551ee104e6e56a255a032fb70ed955", size = 71023 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/76/1758304cf0e165b574736b460720a8b32aa91acd3439231200907ca02c00/tune-0.1.6-py3-none-any.whl", hash = "sha256:bc535dcf5261b2d1e68a83ae0548827bfb0219c88b2d4bf4a67d88e8bb4d5286", size = 95807 },
 ]
 
 [[package]]


### PR DESCRIPTION
### TLDR;
> Improved import time from ~3s to ~0.7s by move heavy module to external. Including `qiskit` and `forest-benchmarking` that are rarely used now.
### Details, 
- Moved `qiskit` and `forest-benchmarking` to `external` module. 
- Implemented lazy import on `ray` dependent code. 