### PR TITLE
fixed/hist-to-any

### DIFF
--- a/src/inspeqtor/experimental/model.py
+++ b/src/inspeqtor/experimental/model.py
@@ -411,7 +411,7 @@ def save_model(
     hamiltonian: typing.Union[str, typing.Callable],
     model_config: dict,
     model_params: VariableDict,
-    history: typing.Sequence[dict[typing.Hashable, typing.Any]] | None = None,
+    history: typing.Sequence[dict[typing.Any, typing.Any]] | None = None,
     with_auto_datetime: bool = True,
 ):
     if not isinstance(path, pathlib.Path):


### PR DESCRIPTION
### TLDR;
> Change typing from `Hashable` in history argument of save model to `typing.Any`.