### PR TITLE
feat/updated-pulse-to-control

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,6 @@ repos:
   hooks:
     # Update the uv lockfile
     - id: uv-lock
-# - repo: https://github.com/RobertCraigie/pyright-python
-#   rev: v1.1.389
-#   hooks:
-#   - id: pyright
-
 - repo: local
   hooks:
     - id: pytest
@@ -30,3 +25,8 @@ repos:
       language: python
       pass_filenames: false
       always_run: true
+- repo: https://github.com/RobertCraigie/pyright-python
+  rev: v1.1.389
+  hooks:
+    - id: pyright
+      args: ["--project", "src/inspeqtor/experimental/."]

--- a/documents/shared/helper.py
+++ b/documents/shared/helper.py
@@ -67,7 +67,7 @@ def get_gaussian_pulse_sequence(
     total_length = 320
     dt = 2 / 9
 
-    pulse_sequence = sq.pulse.PulseSequence(
+    pulse_sequence = sq.pulse.ControlSequence(
         pulses=[
             sq.predefined.GaussianPulse(
                 duration=total_length,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
 ]
 
 [tool.pyright]
-exclude = [".venv", "notebooks"]
+exclude = [".venv", "./notebooks", "./src/inspeqtor/legacy", "./src/inspeqtor/external", "./tests/legacy"]
 pythonVersion = "3.11"
 venvPath = "."
 venv = ".venv"

--- a/src/inspeqtor/experimental/model.py
+++ b/src/inspeqtor/experimental/model.py
@@ -24,7 +24,7 @@ from .physics import (
     Y,
     Z,
 )
-from .pulse import PulseSequence
+from .pulse import ControlSequence
 from .typing import Wos
 
 jax.config.update("jax_enable_x64", True)
@@ -641,7 +641,7 @@ def generate_path_with_datetime(sub_dir: pathlib.Path):
 def save_model(
     path: pathlib.Path | str,
     experiment_identifier: str,
-    pulse_sequence: PulseSequence,
+    pulse_sequence: ControlSequence,
     hamiltonian: typing.Union[str, typing.Callable],
     model_config: dict,
     model_params: VariableDict,

--- a/src/inspeqtor/experimental/optimize.py
+++ b/src/inspeqtor/experimental/optimize.py
@@ -13,7 +13,7 @@ import tempfile
 from enum import StrEnum
 import chex
 
-from .pulse import PulseSequence
+from .pulse import ControlSequence
 from .utils import dataloader, create_step
 from .model import loss_fn, LossMetric, save_model, load_model
 from ray.tune.search.sample import Domain
@@ -219,7 +219,7 @@ def clean_history_entries(
 
 
 def default_trainable_v4(
-    pulse_sequence: PulseSequence,
+    pulse_sequence: ControlSequence,
     metric: LossMetric,
     experiment_identifier: str,
     hamiltonian: typing.Callable | str,

--- a/src/inspeqtor/experimental/physics.py
+++ b/src/inspeqtor/experimental/physics.py
@@ -8,7 +8,7 @@ import diffrax  # type: ignore
 from .typing import ParametersDictType
 from .data import QubitInformation
 from .constant import X, Y, Z
-from .pulse import PulseSequence
+from .pulse import ControlSequence
 
 
 @struct.dataclass
@@ -572,7 +572,7 @@ def unitaries_prod(
 
 def make_trotterization_whitebox(
     hamiltonian: typing.Callable[..., jnp.ndarray],
-    pulse_sequence: PulseSequence,
+    pulse_sequence: ControlSequence,
     dt: float = 2 / 9,
     trotter_steps: int = 1000,
 ):

--- a/src/inspeqtor/experimental/predefined.py
+++ b/src/inspeqtor/experimental/predefined.py
@@ -13,8 +13,8 @@ from .data import (
     make_row,
 )
 from .pulse import (
-    BasePulse,
-    PulseSequence,
+    BaseControl,
+    ControlSequence,
     array_to_list_of_params,
     list_of_params_to_array,
     construct_pulse_sequence_reader,
@@ -105,7 +105,7 @@ def gaussian_envelope(amp, center, sigma):
 
 
 @dataclass
-class GaussianPulse(BasePulse):
+class GaussianPulse(BaseControl):
     duration: int
     # beta: float
     qubit_drive_strength: float
@@ -167,7 +167,7 @@ def get_gaussian_pulse_sequence(
     total_length = 320
     dt = 2 / 9
 
-    pulse_sequence = PulseSequence(
+    pulse_sequence = ControlSequence(
         pulses=[
             GaussianPulse(
                 duration=total_length,
@@ -185,7 +185,7 @@ def get_gaussian_pulse_sequence(
 
 
 @dataclass
-class DragPulseV2(BasePulse):
+class DragPulseV2(BaseControl):
     duration: int
     qubit_drive_strength: float
     dt: float
@@ -255,7 +255,7 @@ def get_drag_pulse_v2_sequence(
     total_length = 320
     dt = 2 / 9
 
-    pulse_sequence = PulseSequence(
+    pulse_sequence = ControlSequence(
         pulses=[
             DragPulseV2(
                 duration=total_length,
@@ -275,7 +275,7 @@ def get_drag_pulse_v2_sequence(
 
 
 @dataclass
-class DragPulse(BasePulse):
+class DragPulse(BaseControl):
     duration: int
     beta: float
     qubit_drive_strength: float
@@ -325,7 +325,7 @@ def get_drag_pulse_sequence(
     total_length = 320
     dt = 2 / 9
 
-    pulse_sequence = PulseSequence(
+    pulse_sequence = ControlSequence(
         pulses=[
             DragPulse(
                 duration=total_length,
@@ -371,7 +371,7 @@ def get_envelope(params: ParametersDictType, order: int, total_length: int):
 
 
 @dataclass
-class MultiDragPulseV3(BasePulse):
+class MultiDragPulseV3(BaseControl):
     duration: int
     order: int = 1
     amp_bound: list[list[float]] = field(default_factory=list)  # [[0.0, 1.0],]
@@ -430,7 +430,7 @@ def get_multi_drag_pulse_sequence_v3():
         global_beta_bound=[-2.0, 2.0],
     )
 
-    pulse_sequence = PulseSequence(
+    pulse_sequence = ControlSequence(
         pulse_length_dt=80,
         pulses=[pulse],
     )
@@ -454,7 +454,7 @@ def get_mock_prefined_exp_v1(
         [], QubitInformation
     ] = get_mock_qubit_information,
     get_pulse_sequence_fn: typing.Callable[
-        [], PulseSequence
+        [], ControlSequence
     ] = get_multi_drag_pulse_sequence_v3,
 ):
     qubit_info = get_qubit_information_fn()
@@ -501,13 +501,13 @@ def generate_experimental_data(
         [], QubitInformation
     ] = get_mock_qubit_information,
     get_pulse_sequence_fn: typing.Callable[
-        [], PulseSequence
+        [], ControlSequence
     ] = get_multi_drag_pulse_sequence_v3,
     max_steps: int = int(2**16),
     method: WhiteboxStrategy = WhiteboxStrategy.ODE,
 ) -> tuple[
     ExperimentData,
-    PulseSequence,
+    ControlSequence,
     jnp.ndarray,
     typing.Callable[[jnp.ndarray], jnp.ndarray],
 ]:
@@ -655,7 +655,7 @@ def generate_experimental_data(
     )
 
 
-def get_envelope_transformer(pulse_sequence: PulseSequence):
+def get_envelope_transformer(pulse_sequence: ControlSequence):
     """Generate get_envelope function with control parameter array as an input instead of list form
 
     Args:
@@ -677,7 +677,7 @@ def get_envelope_transformer(pulse_sequence: PulseSequence):
 
 def get_single_qubit_whitebox(
     hamiltonian: typing.Callable[..., jnp.ndarray],
-    pulse_sequence: PulseSequence,
+    pulse_sequence: ControlSequence,
     qubit_info: QubitInformation,
     dt: float,
     max_steps: int = int(2**16),
@@ -722,7 +722,7 @@ def get_single_qubit_whitebox(
 
 
 def get_single_qubit_rotating_frame_whitebox(
-    pulse_sequence: PulseSequence,
+    pulse_sequence: ControlSequence,
     qubit_info: QubitInformation,
     dt: float,
 ) -> typing.Callable[[jnp.ndarray], jnp.ndarray]:

--- a/src/inspeqtor/experimental/probabilistic.py
+++ b/src/inspeqtor/experimental/probabilistic.py
@@ -242,7 +242,6 @@ def make_probabilistic_model(
         unitaries: jnp.ndarray,
         observables: jnp.ndarray | None = None,
     ):
-
         expvals = graybox_fn(control_parameters, unitaries)
 
         if observables is None:
@@ -306,7 +305,7 @@ def load_pytree_from_json(path: str | pathlib.Path, array_keys: list[str] = []):
     """Load pytree from json
 
     Args:
-        path (str | pathlib.Path): Path to JSON file containing pytree 
+        path (str | pathlib.Path): Path to JSON file containing pytree
         array_keys (list[str], optional): list of key to convert to jnp.numpy. Defaults to [].
 
     Raises:
@@ -359,6 +358,24 @@ def get_args_of_distribution(x):
         return x
 
 
+def construct_normal_priors(posterior):
+    """Construct a dict of Normal Distributions with posterior
+
+    Args:
+        posterior (_type_): Dict of Normal distribution arguments
+
+    Returns:
+        _type_: dict of Normal distributions
+    """
+    posterior_distributions = {}
+    assert isinstance(posterior, dict)
+    for name, value in posterior.items():
+        assert isinstance(name, str)
+        assert isinstance(value, dict)
+        posterior_distributions[name] = dist.Normal(value["loc"], value["scale"])  # type: ignore
+    return posterior_distributions
+
+
 def construct_normal_prior_from_samples(
     posterior_samples: dict[str, jnp.ndarray],
 ) -> dict[str, dist.Distribution]:
@@ -383,15 +400,14 @@ def construct_normal_prior_from_samples(
 
 @dataclass
 class ProbabilisticModel:
-    """Dataclass to save and load probabilistic model from inference result and file. 
-    """
+    """Dataclass to save and load probabilistic model from inference result and file."""
+
     posterior: dict[str, jnp.ndarray]
     shots: int
     hidden_sizes: list[list[int]]
 
     @classmethod
     def from_file(cls, path: str | pathlib.Path) -> "ProbabilisticModel":
-
         data = load_pytree_from_json(path, array_keys=["posterior"])
 
         return cls(
@@ -411,7 +427,6 @@ class ProbabilisticModel:
         sample_shape: tuple[int, ...] = (10000,),
         prefix: str = "graybox/",
     ):
-
         posterior_samples = guide.sample_posterior(
             key, svi_params, sample_shape=sample_shape
         )

--- a/src/inspeqtor/experimental/pulse.py
+++ b/src/inspeqtor/experimental/pulse.py
@@ -37,7 +37,7 @@ def sample_params(
 
 
 @dataclass
-class BasePulse(ABC):
+class BaseControl(ABC):
     duration: int
 
     def __post_init__(self):
@@ -119,10 +119,10 @@ class BasePulse(ABC):
 
 
 @dataclass
-class PulseSequence:
+class ControlSequence:
     """Control sequence, expect to be sum of atomic control."""
 
-    pulses: typing.Sequence[BasePulse]
+    pulses: typing.Sequence[BaseControl]
     pulse_length_dt: int
     validate: bool = True
 
@@ -266,8 +266,8 @@ class PulseSequence:
 
     @classmethod
     def from_dict(
-        cls, data: dict[str, typing.Any], pulses: typing.Sequence[type[BasePulse]]
-    ) -> "PulseSequence":
+        cls, data: dict[str, typing.Any], pulses: typing.Sequence[type[BaseControl]]
+    ) -> "ControlSequence":
         """Construct the control sequence from dict.
 
         Args:
@@ -307,8 +307,8 @@ class PulseSequence:
     def from_file(
         cls,
         path: typing.Union[str, pathlib.Path],
-        pulses: typing.Sequence[type[BasePulse]],
-    ) -> "PulseSequence":
+        pulses: typing.Sequence[type[BaseControl]],
+    ) -> "ControlSequence":
         """Construct control seqence from path
 
         Args:
@@ -371,7 +371,7 @@ def list_of_params_to_array(
     return jnp.array(temp)
 
 
-def get_param_array_converter(pulse_sequence: PulseSequence):
+def get_param_array_converter(pulse_sequence: ControlSequence):
     """This function returns two functions that can convert between a list of parameter dictionaries and a flat array.
 
     >>> array_to_list_of_params_fn, list_of_params_to_array_fn = get_param_array_converter(pulse_sequence)
@@ -398,8 +398,8 @@ def get_param_array_converter(pulse_sequence: PulseSequence):
 
 
 def construct_pulse_sequence_reader(
-    pulses: list[type[BasePulse]] = [],
-) -> typing.Callable[[typing.Union[str, pathlib.Path]], PulseSequence]:
+    pulses: list[type[BaseControl]] = [],
+) -> typing.Callable[[typing.Union[str, pathlib.Path]], ControlSequence]:
     """Construct the control sequence reader
 
     Args:
@@ -408,12 +408,12 @@ def construct_pulse_sequence_reader(
     Returns:
         typing.Callable[[typing.Union[str, pathlib.Path]], PulseSequence]: Control sequence reader that will automatically contruct control sequence from path.
     """
-    default_pulses: list[type[BasePulse]] = []
+    default_pulses: list[type[BaseControl]] = []
 
     # Merge the default pulses with the provided pulses
     pulses_list = default_pulses + pulses
 
-    def pulse_sequence_reader(path: typing.Union[str, pathlib.Path]) -> PulseSequence:
+    def pulse_sequence_reader(path: typing.Union[str, pathlib.Path]) -> ControlSequence:
         """Construct control sequence from path
 
         Args:
@@ -435,6 +435,6 @@ def construct_pulse_sequence_reader(
                 if pulse_dict["_name"] == pulse_class.__name__:
                     parsed_pulses.append(pulse_class)
 
-        return PulseSequence.from_dict(pulse_sequence_dict, pulses=parsed_pulses)
+        return ControlSequence.from_dict(pulse_sequence_dict, pulses=parsed_pulses)
 
     return pulse_sequence_reader

--- a/src/inspeqtor/experimental/utils.py
+++ b/src/inspeqtor/experimental/utils.py
@@ -4,7 +4,7 @@ import typing
 import optax  # type: ignore
 import jaxtyping
 from dataclasses import dataclass
-from .pulse import PulseSequence
+from .pulse import ControlSequence
 from .data import ExperimentData, QubitInformation
 from .model import mse
 from .constant import Z, default_expectation_values_order, plus_projectors
@@ -20,7 +20,7 @@ class LoadedData:
     pulse_parameters: jnp.ndarray
     unitaries: jnp.ndarray
     expectation_values: jnp.ndarray
-    pulse_sequence: PulseSequence
+    pulse_sequence: ControlSequence
     whitebox: typing.Callable
     noisy_whitebox: typing.Callable | None = None
     noisy_unitaries: jnp.ndarray | None = None
@@ -104,7 +104,7 @@ def detune_hamiltonian(
 
 def prepare_data(
     exp_data: ExperimentData,
-    pulse_sequence: PulseSequence,
+    pulse_sequence: ControlSequence,
     whitebox: typing.Callable,
 ) -> LoadedData:
     """Prepare the data for easy accessing from experiment data, control sequence, and Whitebox.
@@ -380,7 +380,7 @@ def recursive_vmap(func, in_axes):
 
 
 class SyntheticDataModel(typing.NamedTuple):
-    pulse_sequence: PulseSequence
+    pulse_sequence: ControlSequence
     qubit_information: QubitInformation
     dt: float
     ideal_hamiltonian: typing.Callable[..., jnp.ndarray]

--- a/src/inspeqtor/external/qiskit.py
+++ b/src/inspeqtor/external/qiskit.py
@@ -35,7 +35,7 @@ from ..experimental.data import (
     make_row,
 )
 from ..experimental.typing import ParametersDictType
-from ..experimental.pulse import PulseSequence
+from ..experimental.pulse import ControlSequence
 from ..experimental.physics import CouplingInformation
 
 
@@ -295,7 +295,7 @@ def get_ibm_service_and_backend(
 
 def prepare_experiment(
     config: ExperimentConfiguration,
-    pulse_sequence: PulseSequence,
+    pulse_sequence: ControlSequence,
     key: jnp.ndarray,
     backend_properties: IBMQDeviceProperties,
 ) -> tuple[pd.DataFrame, list[QuantumCircuit]]:
@@ -718,7 +718,7 @@ class QuantumCircuitData:
 
 def prepare_experiment_v2(
     config: ExperimentConfiguration,
-    pulse_sequence: PulseSequence,
+    pulse_sequence: ControlSequence,
     key: jnp.ndarray,
     backend_properties: IBMQDeviceProperties,
 ) -> tuple[pd.DataFrame, list[QuantumCircuitData]]:
@@ -777,7 +777,7 @@ def prepare_experiment_v2(
 
 def prepare_parallel_experiment_v2(
     configs: list[ExperimentConfiguration],
-    pulse_sequences: list[PulseSequence],
+    pulse_sequences: list[ControlSequence],
     keys: Sequence[jnp.ndarray],
     backend_properties: IBMQDeviceProperties,
     enable_MCMD: bool = True,

--- a/tests/experimental/test_probabilistic.py
+++ b/tests/experimental/test_probabilistic.py
@@ -1,14 +1,14 @@
 import pytest
 import jax
 import jax.numpy as jnp
-import numpyro.distributions as dist # type: ignore
+import numpyro.distributions as dist  # type: ignore
 from inspeqtor.experimental.probabilistic import (
     eigenvalue_to_binary,
     binary_to_eigenvalue,
     expectation_value_to_eigenvalue,
     construct_normal_prior_from_samples,
     get_args_of_distribution,
-    ProbabilisticModel
+    ProbabilisticModel,
 )
 
 
@@ -57,7 +57,6 @@ def test_expectation_value_to_eigenvalue():
 
 @pytest.mark.skip("Not finished")
 def test_save_and_load_model(guide, svi_params, shots, hidden_sizes):
-
     posterior_samples = guide.sample_posterior(
         jax.random.key(0), svi_params, sample_shape=(10000,)
     )

--- a/tests/experimental/test_pulse.py
+++ b/tests/experimental/test_pulse.py
@@ -15,7 +15,7 @@ def test_jax_DRAG_pulse():
 
     # Check to_dict and from_dict
     pulse_sequence_dict = pulse_sequence.to_dict()
-    pulse_sequence_from_dict = sq.pulse.PulseSequence.from_dict(
+    pulse_sequence_from_dict = sq.pulse.ControlSequence.from_dict(
         pulse_sequence_dict, pulses=[sq.predefined.MultiDragPulseV3] * 1
     )
 


### PR DESCRIPTION
### TL;DR

Renamed `PulseSequence` to `ControlSequence` and `BasePulse` to `BaseControl` to better reflect their purpose, and enabled Pyright type checking for the experimental module.

### What changed?

- Renamed `PulseSequence` to `ControlSequence` and `BasePulse` to `BaseControl` throughout the codebase
- Added a new `construct_normal_priors` function in the probabilistic module
- Uncommented and configured Pyright pre-commit hook to run on the experimental module
- Updated Pyright configuration in `pyproject.toml` to exclude legacy, external, and test directories
- Fixed formatting issues in the probabilistic module

### How to test?

1. Run the pre-commit hooks to verify Pyright passes on the experimental module:
   ```bash
   pre-commit run pyright
   ```
2. Run the existing tests to ensure the renamed classes work correctly:
   ```bash
   pytest tests/experimental/.
   ```

### Why make this change?

The renaming from `PulseSequence` to `ControlSequence` and `BasePulse` to `BaseControl` better reflects the purpose of these classes, which are used to represent general control sequences rather than just pulses specifically. This improves code readability and makes the API more intuitive.

Enabling Pyright type checking for the experimental module helps catch type errors early and improves code quality. The additional function `construct_normal_priors` provides a cleaner way to create normal distributions from posterior parameters.