### PR TITLE
feat/minor-updates

### DIFF
--- a/documents/reviews/review_0004_detuning.ipynb
+++ b/documents/reviews/review_0004_detuning.ipynb
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -99,14 +99,14 @@
     ")\n",
     "\n",
     "array_to_list_of_params_fn, list_of_params_to_array_fn = (\n",
-    "    sq.pulse.get_param_array_converter(control_sequence)\n",
+    "    sq.control.get_param_array_converter(control_sequence)\n",
     ")\n",
     "\n",
     "hamiltonian = partial(\n",
     "    sq.predefined.rotating_transmon_hamiltonian,\n",
     "    qubit_info=qubit_info,\n",
     "    signal=sq.physics.signal_func_v5(\n",
-    "        get_envelope=sq.predefined.get_envelope_transformer(\n",
+    "        get_envelope=sq.control.get_envelope_transformer(\n",
     "            control_sequence=control_sequence\n",
     "        ),\n",
     "        drive_frequency=qubit_info.frequency,\n",
@@ -125,7 +125,7 @@
     "    t1=control_sequence.pulse_length_dt * dt,\n",
     ")\n",
     "\n",
-    "whitebox = sq.physics.make_trotterization_whitebox(\n",
+    "whitebox = sq.physics.make_trotterization_solver(\n",
     "    hamiltonian=hamiltonian,\n",
     "    control_sequence=control_sequence,\n",
     "    dt=dt,\n",
@@ -596,7 +596,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "inspeqtor (3.11.10)",
    "language": "python",
    "name": "python3"
   },

--- a/documents/shared/helper.py
+++ b/documents/shared/helper.py
@@ -91,7 +91,7 @@ def get_data_model(trotterization_solver: bool = False) -> sq.utils.SyntheticDat
         sq.predefined.rotating_transmon_hamiltonian,
         qubit_info=qubit_info,
         signal=sq.physics.signal_func_v5(
-            get_envelope=sq.predefined.get_envelope_transformer(
+            get_envelope=sq.control.get_envelope_transformer(
                 control_sequence=control_sequence
             ),
             drive_frequency=qubit_info.frequency,
@@ -111,7 +111,7 @@ def get_data_model(trotterization_solver: bool = False) -> sq.utils.SyntheticDat
         dt=dt,
     )
 
-    trotter_solver = sq.physics.make_trotterization_whitebox(
+    trotter_solver = sq.physics.make_trotterization_solver(
         hamiltonian=total_hamiltonian,
         control_sequence=control_sequence,
         trotter_steps=1000,

--- a/documents/shared/shared_0004_reparametrized_v3.ipynb
+++ b/documents/shared/shared_0004_reparametrized_v3.ipynb
@@ -404,13 +404,13 @@
     "    sq.predefined.rotating_transmon_hamiltonian,\n",
     "    qubit_info=qubit_info,\n",
     "    signal=sq.physics.signal_func_v5(\n",
-    "        sq.predefined.get_envelope_transformer(control_sequence=control_sequence),\n",
+    "        sq.control.get_envelope_transformer(control_sequence=control_sequence),\n",
     "        qubit_info.frequency,\n",
     "        dt,\n",
     "    ),\n",
     ")\n",
     "\n",
-    "whitebox = sq.physics.make_trotterization_whitebox(\n",
+    "whitebox = sq.physics.make_trotterization_solver(\n",
     "    hamiltonian, control_sequence, dt, control_sequence.pulse_length_dt\n",
     ")\n",
     "jax.vmap(whitebox)(loaded_data.control_parameters).shape"
@@ -661,7 +661,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "inspeqtor",
+   "display_name": "inspeqtor (3.11.10)",
    "language": "python",
    "name": "python3"
   },

--- a/src/inspeqtor/experimental/control.py
+++ b/src/inspeqtor/experimental/control.py
@@ -440,3 +440,23 @@ def construct_control_sequence_reader(
         return ControlSequence.from_dict(control_sequence_dict, pulses=parsed_pulses)
 
     return control_sequence_reader
+
+
+def get_envelope_transformer(control_sequence: ControlSequence):
+    """Generate get_envelope function with control parameter array as an input instead of list form
+
+    Args:
+        control_sequence (PulseSequence): Control seqence instance
+
+    Returns:
+        typing.Callable[[jnp.ndarray], typing.Any]: Transformed get envelope function
+    """
+    structure = control_sequence.get_parameter_names()
+
+    def array_to_list_of_params_fn(array: jnp.ndarray):
+        return array_to_list_of_params(array, structure)
+
+    def get_envelope(params: jnp.ndarray) -> typing.Callable[..., typing.Any]:
+        return control_sequence.get_envelope(array_to_list_of_params_fn(params))
+
+    return get_envelope

--- a/src/inspeqtor/experimental/model.py
+++ b/src/inspeqtor/experimental/model.py
@@ -743,6 +743,7 @@ def unitary(params: jnp.ndarray) -> jnp.ndarray:
     theta = params[..., 0]
     alpha = params[..., 1]
     beta = params[..., 2]
+    psi = params[..., 3]
 
     q_00 = jnp.exp(1j * alpha) * jnp.cos(theta)
     q_01 = jnp.exp(1j * beta) * jnp.sin(theta)
@@ -755,14 +756,16 @@ def unitary(params: jnp.ndarray) -> jnp.ndarray:
     Q = Q.at[..., 1, 0].set(q_10)
     Q = Q.at[..., 1, 1].set(q_11)
 
-    return Q
+    psi_ = jnp.expand_dims(jnp.exp(1j * psi / 2), [-2, -1])
+
+    return psi_ * Q
 
 
 class UnitaryModel(nn.Module):
     # feature_size: int
     hidden_sizes: list[int]
 
-    NUM_UNITARY_PARAMS: int = 3
+    NUM_UNITARY_PARAMS: int = 4
 
     @nn.compact
     def __call__(self, x: jnp.ndarray):

--- a/src/inspeqtor/experimental/physics.py
+++ b/src/inspeqtor/experimental/physics.py
@@ -570,7 +570,7 @@ def unitaries_prod(
     return prod_unitary, prod_unitary
 
 
-def make_trotterization_whitebox(
+def make_trotterization_solver(
     hamiltonian: typing.Callable[..., jnp.ndarray],
     control_sequence: ControlSequence,
     dt: float = 2 / 9,

--- a/src/inspeqtor/experimental/probabilistic.py
+++ b/src/inspeqtor/experimental/probabilistic.py
@@ -152,6 +152,23 @@ def unitary_model_prediction_to_expvals(output, unitaries: jnp.ndarray) -> jnp.n
     )
 
 
+def unitary_model_prediction_to_expvals_v2(
+    output, unitaries: jnp.ndarray
+) -> jnp.ndarray:
+    UJ: jnp.ndarray = unitary(output)  # type: ignore
+    UJ_dagger = jnp.swapaxes(UJ, -2, -1).conj()
+
+    X_ = UJ_dagger @ X @ UJ
+    Y_ = UJ_dagger @ Y @ UJ
+    Z_ = UJ_dagger @ Z @ UJ
+
+    return get_predict_expectation_value(
+        {"X": X_, "Y": Y_, "Z": Z_},
+        unitaries,
+        default_expectation_values_order,
+    )
+
+
 def wo_model_prediction_to_expvals(output, unitaries: jnp.ndarray) -> jnp.ndarray:
     """Function to be used with Wo-based model for probabilistic model construction
     with `make_probabilistic_model` function.

--- a/src/inspeqtor/experimental/visualization.py
+++ b/src/inspeqtor/experimental/visualization.py
@@ -141,3 +141,25 @@ def set_fontsize(ax: Axes, fontsize: float | int):
     legend, handles = ax.get_legend_handles_labels()
 
     ax.legend(legend, handles, fontsize=fontsize)
+
+
+def plot_control_envelope(
+    waveform: jnp.ndarray,
+    x_axis: jnp.ndarray,
+    ax: Axes,
+    font_size: int = 12,
+):
+    ax.bar(
+        x_axis, jnp.real(waveform), label="Real component", color="orange", alpha=0.5
+    )
+    ax.bar(x_axis, jnp.imag(waveform), label="Imag component", color="blue", alpha=0.5)
+
+    ax.set_xlabel("Time", fontsize=font_size)
+
+    # Text size
+    ax.tick_params(axis="both", labelsize=font_size)
+
+    ax.set_xlabel("Time (dt)", fontsize=font_size)
+    ax.set_ylabel("Amplitude", fontsize=font_size)
+
+    ax.legend(fontsize=font_size, loc="upper right")

--- a/tests/experimental/test_physics.py
+++ b/tests/experimental/test_physics.py
@@ -139,7 +139,9 @@ jax.config.update("jax_enable_x64", True)
 
 def test_signal_func_v3():
     qubit_info = sq.predefined.get_mock_qubit_information()
-    control_sequence = sq.predefined.get_drag_control_sequence(qubit_info)
+    control_sequence = sq.predefined.get_drag_control_sequence(
+        qubit_info.drive_strength
+    )
     dt = 2 / 9
 
     key = jax.random.PRNGKey(0)
@@ -164,7 +166,9 @@ def test_signal_func_v3():
 
 def test_hamiltonian_fn():
     qubit_info = sq.predefined.get_mock_qubit_information()
-    control_sequence = sq.predefined.get_drag_control_sequence(qubit_info)
+    control_sequence = sq.predefined.get_drag_control_sequence(
+        qubit_info.drive_strength
+    )
     # control_sequence = sq.predefined.get_gaussian_control_sequence(qubit_info)
     dt = 2 / 9
 
@@ -454,7 +458,7 @@ def solver_with_trotterization():
         ),
     )
 
-    whitebox = sq.physics.make_trotterization_whitebox(
+    whitebox = sq.physics.make_trotterization_solver(
         hamiltonian, control_sequence, time_step, trotter_steps=1000
     )
 
@@ -490,7 +494,9 @@ def test_crosscheck(unitaries):
 @pytest.mark.skip(reason="4 / 320 mismatch somehow")
 def test_crosscheck_pennylane_difflax():
     qubit_info = sq.predefined.get_mock_qubit_information()
-    control_sequence = sq.predefined.get_drag_control_sequence(qubit_info)
+    control_sequence = sq.predefined.get_drag_control_sequence(
+        qubit_info.drive_strength
+    )
 
     key = jax.random.PRNGKey(0)
     params = control_sequence.sample_params(key)


### PR DESCRIPTION
### TL;DR

Refactored API functions and improved model architecture by moving functions to more appropriate modules and enhancing the unitary model.

### What changed?

- Renamed `make_trotterization_whitebox` to `make_trotterization_solver` for better clarity
- Moved `get_envelope_transformer` from `predefined.py` to `control.py` to better organize related functionality
- Updated the unitary model to include a fourth parameter `psi` for global phase
- Improved shot-based simulation strategy in `generate_experimental_data` to use `shot_quantum_device`
- Added a new visualization function `plot_control_envelope` for displaying control waveforms
- Updated function signatures to accept specific parameters rather than entire objects (e.g., `qubit_info_drive_strength` instead of `qubit_info`)
- Fixed imports and updated function calls throughout the codebase to match these changes