### PR TITLE
fixed/fix-the-test-data

### DIFF
--- a/tests/experimental/test_data.py
+++ b/tests/experimental/test_data.py
@@ -174,7 +174,8 @@ def test_get_parameters_dict_list_2():
         parameters_name, df_params.iloc[0]
     )
 
-    assert parameters_dict_list == pulse_params
+    # assert parameters_dict_list == pulse_params
+    chex.assert_trees_all_close(parameters_dict_list, pulse_params)
 
 
 def test_ExperimentData_1(tmp_path):


### PR DESCRIPTION
### TL;DR

Replace equality assertion with `chex.assert_trees_all_close()` in test_data.py

### What changed?

Modified the assertion in `test_get_parameters_dict_list_2()` to use `chex.assert_trees_all_close()` instead of direct equality comparison. The previous assertion `assert parameters_dict_list == pulse_params` has been commented out and replaced with a more robust comparison method.