### PR TITLE
tests/add-multiple-version-ci-test

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -29,13 +29,27 @@ jobs:
             - uses: actions/checkout@v4
             - uses: ./.github/actions/setup
             - run: uv run pyright src/inspeqtor/experimental/.
-    tests:
+    tests_py3-13:
         runs-on: ubuntu-latest
         needs: [lock_file]
         steps:
             - uses: actions/checkout@v4
             - uses: ./.github/actions/setup
-            - run: uv run pytest tests/experimental/. -vv --durations=0
+            - run: uv run --python 3.13 --with '.[test]' pytest tests/experimental/. -vv --durations=0
+    tests_py3-12:
+        runs-on: ubuntu-latest
+        needs: [lock_file]
+        steps:
+            - uses: actions/checkout@v4
+            - uses: ./.github/actions/setup
+            - run: uv run --python 3.12 --with '.[test]' pytest tests/experimental/. -vv --durations=0
+    tests_py3-11:
+        runs-on: ubuntu-latest
+        needs: [lock_file]
+        steps:
+            - uses: actions/checkout@v4
+            - uses: ./.github/actions/setup
+            - run: uv run --python 3.11 --with '.[test]' pytest tests/experimental/. -vv --durations=0
     build:
         runs-on: ubuntu-latest
         needs: [lock_file, linting, formatting, tests]

--- a/developer/README.md
+++ b/developer/README.md
@@ -54,6 +54,11 @@ uv run pytest tests/experimental/. -vv --durations=0
 ```
 where the flag is for complehensive reporting.
 
+To test with the specific version of python, use the following,
+```bash
+uv run --python 3.12 --with '.[test]' pytest tests/experimental/.
+```
+
 - We use `ruff` for linting and formatting. To run the linter, run the following command:
 
 ```bash


### PR DESCRIPTION
### TL;DR

Added multi-Python version testing to the CI workflow.

### What changed?

- Split the single test job into three separate jobs for Python 3.11, 3.12, and 3.13
- Updated the CI workflow to run tests against each Python version
- Added documentation in the developer README on how to test with specific Python versions

### How to test?

Run tests with a specific Python version using:
```bash
uv run --python 3.12 --with '.[test]' pytest tests/experimental/.
```

### Why make this change?

To ensure compatibility across multiple Python versions (3.11, 3.12, and 3.13) and catch any version-specific issues early in the development process.