### PR TITLE
docs/added-instruction

### DIFF
--- a/developer/README.md
+++ b/developer/README.md
@@ -95,6 +95,12 @@ To perform profiling, we use `tuna`
     uvx tuna import.log
 ```
 
+You can test the docstring using the following command
+```bash
+uv run -m doctest src/inspeqtor/experimental/utils.py
+```
+
+
 ## For using sphinx auto genereate documentation:
 
 Setting things up


### PR DESCRIPTION
### TL;DR

Added instructions for running doctests in the developer documentation.

### What changed?

Added a new section to the developer README.md that explains how to test docstrings using the `doctest` module. The example shows how to run doctests on a specific file (`src/inspeqtor/experimental/utils.py`) using the `uv` package manager.

### How to test?

Follow the new instructions in the README:
```bash
uv run -m doctest src/inspeqtor/experimental/utils.py
```

### Why make this change?

To help developers verify that code examples in docstrings are correct and working as expected. This promotes better documentation practices and ensures that examples remain accurate as the codebase evolves.