### PR TITLE
feat: implement pure get expectation values function

### DIFF
--- a/docs/tutorials/tutorial_0003_cc.ipynb
+++ b/docs/tutorials/tutorial_0003_cc.ipynb
@@ -85,7 +85,7 @@
     {
      "data": {
       "text/html": [
-       "<script> (()=>{ if (customElements.get('treescope-container') === undefined) { class TreescopeContainer extends HTMLElement { constructor() { super(); this.attachShadow({mode: \"open\"}); this.defns = {}; this.state = {}; } } customElements.define(\"treescope-container\", TreescopeContainer); } if (customElements.get('treescope-run-here') === undefined) { class RunHere extends HTMLElement { constructor() { super() } connectedCallback() { const run = child => { const fn = new Function(child.textContent); child.textContent = \"\"; fn.call(this); this.remove(); }; const child = this.querySelector(\"script\"); if (child) { run(child); } else { new MutationObserver(()=>{ run(this.querySelector(\"script\")); }).observe(this, {childList: true}); } } } customElements.define(\"treescope-run-here\", RunHere); } })(); </script> <treescope-container class=\"treescope_out_0da14502c8034ea08121d36f6e6019db\" style=\"display:block\"></treescope-container> <treescope-run-here><script type=\"application/octet-stream\"> const root = ( Array.from(document.getElementsByClassName( \"treescope_out_0da14502c8034ea08121d36f6e6019db\")) .filter((elt) => !elt.dataset.setup) )[0]; root.dataset.setup = 1; const msg = document.createElement(\"span\"); msg.style = \"color: #cccccc; font-family: monospace;\"; msg.textContent = \"(Loading...)\"; root.state.loadingMsg = msg; root.shadowRoot.appendChild(msg); root.state.chain = new Promise((resolve, reject) => { const observer = new IntersectionObserver((entries) => { for (const entry of entries) { if (entry.isIntersecting) { resolve(); observer.disconnect(); return; } } }, {rootMargin: \"1000px\"}); window.setTimeout(() => { observer.observe(root); }, 0); }); root.state.deferring = false; const _insertNode = (node) => { for (let oldScript of node.querySelectorAll(\"script\")) { let newScript = document.createElement(\"script\"); newScript.type = oldScript.type; newScript.textContent = oldScript.textContent; oldScript.parentNode.replaceChild(newScript, oldScript); } if (root.state.loadingMsg) { root.state.loadingMsg.remove(); root.state.loadingMsg = null; } root.shadowRoot.appendChild(node); }; root.defns.insertContent = ((contentNode, compressed) => { if (compressed) { root.state.deferring = true; } if (root.state.deferring) { root.state.chain = (async () => { await root.state.chain; if (compressed) { const encoded = contentNode.textContent; const blob = new Blob([ Uint8Array.from(atob(encoded), (m) => m.codePointAt(0)) ]); const reader = blob.stream().pipeThrough( new DecompressionStream(\"deflate\") ).pipeThrough( new TextDecoderStream(\"utf-8\") ).getReader(); const parts = []; while (true) { const step = await reader.read(); if (step.done) { break; } parts.push(step.value); } const tpl = document.createElement('template'); tpl.innerHTML = parts.join(\"\"); _insertNode(tpl.content); } else { _insertNode(contentNode.content); } })(); } else { _insertNode(contentNode.content); } }); </script></treescope-run-here><div style=\"display:none\"> <script type=\"application/octet-stream\" >eNrtnQt307i2x7+KJ7Pupb3QIMmSLJeh66alL2aAgTIDw5xZvXompokdHKcPzuK7X9lJH2mTlsaNSXJUWH3Ysl77r629f3HiX3rZWVtv1LNU655MuvowTZLM+7fXTXpRFiXxupfqNs+iY/3MM0mcrRneidpn614niZNel0t7/KQVZXqt+GPd66b2SDvqZWtF1WvZWdcejZPYHhZcHjXTpB+rNZm0k3R9cOkzb/iXaNsCtr5IZa11z0SZLRZnOs6eeZ0oXhsehwD8l60rOV3rRV+juGmvS1Kl0zV76JnX5UrZg2ttbbJ1D8lW3ptYr7V01GzZI7BO8vbijEd2cBf1D39ZO456kYjaUWaHyPtZclF2LYqzNIp7kcyb1YOzw3F9++XpYB5/uZjHtbQf2zZTe6wn06ibeflEPH/Eu912JHk+tU8Tmel8mlLNO482VlZWn2/Ymbft9TJPaRP3vOde1op69abO3lmzvE6UXlmtt5JeVi/O26HpzDvs6jgfckPmteYX/f3PuDN7PFZtbU/H/Xb72aCFuu3mQZLE9ujKSZIerXpX+5B8sIfyUyOHs0jmB7s6NUna4bHU9Tg5WVkthGAbWLlxxlsbXPSL56NVW09kvJVrva63ddzMWt7z5x7Ii9za9VRn/TS28+7pdk9fdqzVj/OeXa+614pMlvevKJD/8s3+m9DCipVfrJKTeqq/9HUva8RRpzDXTso7emUwJ6t5Hc9uNNTt91qDaXw2ZoznTTwfDOOWUX5/H/JeDAyZJc1me7B8D4slZtXazevKj+h29sTTx1bgQ0vmvSv+rh/ps3zSa2kt79CwcF22ea/3m13Fw3pXahd1HnasDGvnjX9btfNp5V9ofOOXp+MWgIqOvaLC57VRP1PzMi7sSPXp8xqo2aWbZjeLJLHtop2M2J66bTGMn4GV/JrzsdfsYhz4u8LhHHIhUn1c6KfwPz9ThjgAdlTDAjLpdOyFV0rw4isf/LUifD1OspX1VnKs09Ux5YfF7VisQNSVGoH9MuayRNzvCJ1eLRAySOhlgV7uh5pX++RDAklewE6ETlOtDrvWk+pW0lYjNfEg/zd05MVMrHtRxq1Dyi82tjgXdgZjO7UTtgA77JFih4NJt6VV1LONnp27+usFvQ2vzYVur68LbZ2DvtIrWXw9G9vewIuvwdyND92/Nc9FW1Fc+HbRTvJ9Y2KbhVFutqx4etTTvGkFF9+8urDntUMt3lvZKOrcGDsPAw3IlpZHWq2uev+zetmH/NLxF52XH+lhsR2te4/+hYiQj35k90YvmthJWkEnczvmDffTXm7AbmI3ZZ2OaTfqPVyzxVIoGlor3EhvksYfptXL4WX6NLvZSj3qHZoo7WWHSXyYy3/M0rptKdURyVfTWFN5pbs/sPj1Luaj6vC0acOoQTeKBf2tZGvWH3bPRD/LbPwyzgFdnh4n2ppXu1bKTqQNYscX/peGWNWuxcCPXnGrioi3vYOzjkjaPe9NP8vHq7ytwZX2Z/fMLoy1Ey2ObDw78Lwdu0W1isiVx5m9POI9rS6i4J81yP89uynzwdVF9Anqoe5cH+VgfYwZxXh3d3ll/YT3DqXdB+zEXlzPTTaye5z76dvavHbNaJNXp9475unK2priGV/jsTVsEd+sXj2cN5IHbSmPz9VcVOvBnqftjNmIfC3pZ/cbykUPrGEirX4a7UnRpPdT1OkmacbjG3WLNDnS8WF+5NIZ3T27Vy67Mp/nZv5Wz0Mg2zF1KG0ArVIdD7s6mqLYOkcLPpB3vbJ0hhvpyFKVvC1XbB5lg3jYPS3ivnov4/n1F/2dWU+Gmd2gJyrJ7NjzXlydvC993o5tWHxoM08TndpKRpYJK5aJzQF4Hhed8DS2C+/w3LGf28IYLqE/pmDXBtH/vkgq02EOmXuv4SQND62BeuFWL1Pc9SLv5OlaM+UqsmZb8aBPlG4+8RIr6ab2gO0ela0nA4nb6Dd3GMUhbzjNN/pyw7M+jNv2bjjo8/F8q5+0rHTzSHmcj823POuIx5YZBGdXStlWJ1U0qMFao8271hfeHU/ef7OY3MJlRweF9Kl1GmpimYfox7gmRqbiMoUbNxWjOVJ9NDfzbqnh+lDjkWxxfMHvaWxiPQ8ISPKc1fupkab8rG7SpGPzYNnPc696vuB79WPetsnyyupqvZfYLLlwA3m2m/+sD7bsPNP9zk279sguitULttBraZ3lAEKfeFsHBwf5aA7yYzlOKE7aZL3Iug7OYrnyf/87DBSkPndI9w8arqZpcQ5U2sNjJ0OWhfNctZfKda+ftlfyHWw9P//0JDEGPRN2j6T4iQLh7qtmY7NRfO2/bTSS4rfNdyf2+95Oo7HduO1rs9NoNI+SX9X+9ubWyV+Nxvu/tl42Xu1vbjV2mqf7e7+1st7mq0g3/Z0XH9Fv+/Sv44NuP/r9FXkPX37cf/fnq+MPr75mv5/t7Gw9/tA8eh9tvgCt6MXb/stttfsZ7Imn5nhfdb/8SltfPkTR2/6reLe1Z/7IGn/Qzdcpbuzsx0fbVP7R78eP35Evsnd0cmx22k+/nDa3E9YUL092GdxrPI0b78hvafoSvnvc/AreKdB4aWDzdbB1svsZNUFy1n8XBJ1tSE/2PoZvms2ufn90hvW++EqkSN/sZrzRfLv/+uQF75313vb39z9+2N45afz+trv/l/rj6dPHzeB98NHPgPn19y+NY2Lr/K3xOmi8Oml0ml/fHTzufzrQ2x9PkaHy62v8bu+M9Dcbv37d/Nzd6frR3tutbfCp/zs+CGKz+dv23s6rTiN6zI63USuGreCx+PPk4+eTvfT4xe4fW/Fns73dzB6/kZ/a7YCEWy9PNlkrxK9e7R74u58azc4++bz5Nsze7+q9cHtzc3/Xf9HE757+Jc9EY9fa9M9fnzbe7vKGfrXVbux93X7T/JQ16ebvzTdv9l9sHkVvid7Z/Li1uSMj0G2lSTe22uh+2n4Bv8KjA7NlstbZr/Ge4ju9PQNed3a3X9NN1fjy559dnvUOPnWU4lGIzNcQ/xF9/kK7nZS+Sf7aOojS3c7xy13/4MOBv7ON5OZb8/7xXjvp7uKd3gnhzS+URZ/0wet290O8ubev1atU9z982d3qwA876dHBwSlB9MOH3knD9mjVK2BitvKokPWjfGv8P/vtYvVzlXRtXHC5JAsEWq/XbynxZLBm/7F13Q6VWgWTK0K3QVRp67byiKW3MgjuRompXYLvk3z52mLD4C8/1rPuIa8ij2bzEJCf8CjzYn4cNXmWpHVbc1ckPFX1kzTK9Hub+K1c1mUHO6zrEsvZgGSldiXUzYGcbeV91NE2Jl45J7Y3rkt1x8atNy799sRDAIAi7LDO10YgK0XSNr7dK/Fs7bJzebp67sFyhlnzfvZ2eNS2ji1LvLzwT4Vns4FGbGM2640jO2eaqzwcf3x17oZw8Q6smIf251xxlPtcD5JqG78MduhforjbH+40tWJPFslpbWwlw+3bnhxs3bYTxcWj7Y7utLXRk9ci09qGHW9Xf8kNbvd/uwfk4uTtQiF1O1h76cbwx/bFeTujJmr202JHXPnl6XAgV9p5dB5XPRo9nB86bB+3Rw/XbiQbtdvO1za+9EWU9Z5Pnu4Hnd2/x47wMpd65CXxVq7b54/uuXALErz6yLtI9J7X6oOx1bxik31eu5IF2n16eDbP3q/nqfZsIVTrCFv29+EMbozasEIbVbQWql0Db/Pp348H3n+i+Gcrjb/BP7erwxZYBIH04ygbXcJXX0uobfz3z6coeLa793Xwy7CDT27a+SKBqm14Y4ZRG8luahWbqp4P8057FaWmN9pEE473nIeROh0384OXeWobYFHn+mJ0d0/4RdEqZp3HLZ52kjiSUXZ228yvgTpa1MkfGeTdBhgpXoURTPHKdSxvNQCp25CTLKoJLoZ49/RfFK1i6lUaHevcsRc3VNzqeupwUSd/dJB3W2C0fCVm4Jm+e8dFAJE1wNZQ4AGwjuE6IiM78G1T/mQOzWIH/R3GsKUeygR32eXRBZq+FkGN3L1hzdHOxs751RtFahvUM5Fuq169Xp9c+LLO5mWdgx+rC2nWGUbAP9KY0NNtXfChKa35zyJ6z1klu9/vGfO8Tw6qPhww+8PiVb4ZIYYfhBYmjXLS/E8q7/DDPfHDBSosmEJR6LCfRe0rf+avHh3yzJa3lte9lYkrdEZkb2jnP3Mz39rok8nOY+QVt9rGxRjmQeO37Bm3XLIISo/iKL9hx0Zx3xXePV5EnHKLieoj45/CxqMVVLHbJKKn0+Pcl9xtro/LZq7LwU9jq8urf0hYMM5ew9unaxuvk1gvj51unJvGXDfOVWG1kfV8bNtPzuO4SD2vXdyPjkMdQM6o4FBhJSBXyGdYSiUpMMLX19zuuPvYh2H9eF//mZ/WiztDvDvSBlvwvIiN7LttfUrxCnriwdWb8f2y+euBeUp77UE1VYrLHu1F2dlhh1t3fTpOX4ITGmpACQ4EFoQJrIyGwueBQlzw8IfrCy23vkYtVEZiozVVGyHcIrCQ44BpZLgi1AossP8pE4HgVmIM+vMpsIXATN8XgZRQ1o1K/rPZ4+J7nUpzy+/3I46COAoyIjt4f6XCZaQga0uVVsOyFAQ6ClKtuUpQEOgoSHV2Kk9B4HxTEKl9jQiUQlKJhfEFg4wpDrgIMaKCOQpSgb+ekoLABaAgmAYkUIowTDgWnAoU+hj5RDEQIk2xoyCz1VdJCgLnnoIEPPRhKEwoiBWWEJwrEmofAx2GIcWOgsw4fimhLEdBloqCVJxbOgriKMiUSkX3VypaRgqSLlVajcpSEOQoSLXmKkFBkKMg1dmpPAVB801BmDRQyFDwAGBMMWUCEQIEl1BKIufgpdRlpCDoYSgIWgAKEgrABaASM6AxgZSHoVAohEFgGAgC5ijIbPVVkoKg+acgoZSQME4J0phTLRCGjFDCIMEkNMBRkNnGLyWU5SjIUlGQinNLR0EcBZlSqf79leovIwVpL1Va7ZelIL6jINWaqwQF8R0Fqc5O5SmIP98URAgSMJsscEFDrDAOAWbIaImlogCGyFGQCvz1lBTEXwAK4vtEBEKqQPEQawDCkIMQ6JBrqChx74iZtb5KUhB/7ikIDDWAMiBEq/zdVoFQyCqMEw4lsPpijoLMNn4poSxHQZaKglScWzoK4ijIlErF91cqXkYKApYqrcZlKQh2FKRac5WgINhRkOrsVJ6C4Dl/R4wyGGNNDA4ZNkIJiJgvGaBUCp8ydy9IFf56SgqCF4CCcEgp5NSHEmEccigAIQRryBAWREjjKMhs9VWSguAFuBfEQElAwAT0MQlxKCFHhhmEGIeEUkdBZhu/lFCWoyBLRUEqzi0dBXEUZEqlkvsrlSwjBYFLlVaTshSEOApSrblKUBDiKEh1dipPQcicvyMmNBhLKXkgNA6xEkT6RnNh/wS+moPPbVhGCkIehoKQBaAgUuoQERPykDPsc8IQhjqkjAGEoFS+oyCz1VdJCkLmnoJoqoBmgiJICA4UFhAZxoSvqVFWYcZRkNnGLyWU5SjIUlGQinNLR0EcBZlSqfT+SqXuGTHz7n9oWQpC55yC/LVs5ipBQaijINXZqTwFofNNQQKkQm7TCKVogBUnAjLGECNKhzahkO5ekCr89ZQUhC4ABaGCE6kUDzSmmFHGuPYVIwQQwCAj7nNBZqyvkhSEzv8zYjQXKISh/RthTHwRKBBiBiAUIdQKOgoy2/ilhLIcBVkqClJxbukoiKMgUyo1uL9SA/eMmHn3P0FZChI4ClKtuUpQkMBRkOrsVJ6CBHP+uSD5ZzRAoA3VEhuoGeUmkEzKMGS+DoGjIBX46ykpSLAAFMQQJiEiOuCKYRIKJhUB2LfaUj4NMXEUZLb6KklBgvmnIERC67Yk4ApjDKgVmNAcQeD7AYccOQoy2/ilhLIcBVkqClJxbukoiKMgUyqV3V+pzD0jZt79DytLQZijINWaqwQFYY6CVGen8hSEzTcFAVjZbIEbJKnAwmccMsyZNtwIKICRjoJU4K+npCBsASgIgwCwkEuApI+1NkKS/KN3dWBCgWkYOAoyW32VpCBs7imIYhCxQCKkfJw/Hpf5RvgSQoWN1j5394LMOH4poSxHQZaKglScWzoK4ijIlEoN76/U0D0jZt79T1iWgoSOglRrrhIUJHQUpDo7lacg4XxTEK58gTn3EbJJhKCQUaAF0L5Bvsjfx+AoSAX+ekoKEi4ABdFCCwWVNEAzTH0W6pAQLAFESlqdYUdBZquvkhQknH8KAnwdUIyRH+bggwmNpUISMiQCDhF3FGS28UsJZTkKslQUpOLc0lEQR0GmVCoE95eqvcY9JWbOPZC1UUkQcqMGR0JmbbASKGT0csdCZmyp8jBkbC1zREMMYYHkGHOiMPYNDX1mMFWIC8wZ9N0Tcyvx2lPikAn1zBcPQUiHAeV+QKDCTIWM5I+N0YwY4FNCkeMhM1ZYSSAyuaq5ISKSKKpDERBEEdaECuH7+UfQCCZCFoTu3TGzjmPKaMsxkaViIpVnmo6KOCoyrVbhFFqF7qkxc++DYGkqAh0VqdhgZagIdFSkQks9ABWBc/5OGQK0zU0hBVzgUMAQEqokxwwqm1kE3FGRKrz2tFQELgAVCbGPFDEAKM5xIDj3Q6YCP4AEMMo5dVRkxgorS0Xg/D9FF2CKAM4fBQ4xCZFAvg4I5xIYbYj75NSZxzFltOWoyHJRkaozTUdFHBWZVqtoCq0i9xSZufdBqDQVQXNORT4tncHKUBHkqEiFlnoAKoLmm4oghAIcat9grDDjPAxhECJKgM1iQSADR0Wq8NrTUhG0CJ+jqnyIfUmUDDg2CgogoC8RDRnTUAr33plZK6wsFUFzT0UMwUb7VDDKfKwpZApqrAzyAePGCHevyKzjmDLaclRkuahI1ZmmoyKOikyrVX8KrfruqTJz74P80lTEd1SkYoOVoSK+oyIVWuoBqIg/51SESx+ElAgYGIwAZRwDaGgQAsUgA8xRkSq89rRUxF8AKgK1BspwrHzDsAoUw1wGCgKlqWZQaUdFZqywslTEn3sqIiAkgPrYJxxgInFIDTPID4zxjTShdlRkxnFMGW05KrJcVKTqTNNREUdFptUqnkKr2D1lZu59EC5NRbCjIhUbrAwVwY6KVGipB6AieM4/ZZUBLAlk2giMbWIR0vzjL0PEQgCMCaijIlV47WmpCF4AKkIh0FCHgArEMUSA+UKagITIMA4xDh0VmbHCylIRPPdUBOKQSO5TIPL3/inEofEl4Rxp5HOo3CetzjqOKaMtR0WWi4pUnWk6KuKoyLRaJVNolbinzsy9DyKlqQhxVKRig5WhIsRRkQot9QBUhMw3FQmQlFRoGlAIsaQ+J0pQwanEzH6D7gm8lXjtaakIWQAqQnxAAq6pQlhhBBFjEECDJEA+FIy5Z/DOWmFlqQiZeyrCKRahDLDAwv5GfMGw7xOocjbiz8MDtJaQipAHoSLEUZFloyJVZ5qOijgqMq1W6RRape4ZNHPvg2hpKkIdFanYYGWoCHVUpEJLPQAVoXNORTRhlCuuIAOYc8olQTTkvhJBwH3qnshbideelorQRfhcESNVoELODQkxkaHwhYbQBDrQOgRz8B4ttOQKK0tF6NxTEQohxJTIAGuEUWDjbQClkZQYA4y7V2T2cUwZbTkqslxUpOpM01ERR0Wm1WowhVYD9wyaufdBQWkqEjgqUrHBylCRwFGRCi31AFQkmPN30ARShgoHxlCOWQiYzWApwzbJ4Iwo7T5XpBKvPS0VCRaAijApodBSQEMIFgFkEhAj80/BZD7QAXRUZMYKK0tFgvl/B00QCsglMoHCWCOR3+aGAgMpCpUmCDsqMuM4poy2HBUZoSILL4tq88wfaXLIPN3W+RVTW/2f5dhv7mvzKnaOLk95R2c6PczBUO/5ZCb2IAjs70pBz7XBTZr/a8UWAedUjS5/qN3+nvwY85slF85642hO1tIZX0Sic9Me9zLe3z/g4fPj5l9cn/6FiDfGzCe8z+TDBY0w0IMFGAtq5iq84w8NIc8N/B8SQFYdt3y/5xRcHulYFQ3e/aKE4Uf68OI1xsNM97JF3NSuDnqSLa6WqcIQvVaS9cZZIO53RA5qIABgsaa5GNKk+S1OVjGx2x9/3363/2r79fvD/Rf2+/7O/va7u6W+qNoeO9xJRhhbuGKjvG/sHixXlnptcN8x+Xmx5chzrq+ahQjArlnilgDsZkkXgC2YV6xkSX6/J1S6J9Oom1d996a0q2Odcnu1Z5LUW9Qt6sqQJxniSpFqjHAcSdvtM2k7n0Udu43cGouBOrr2tWgWuDneyaa4WbaSgFh/6evYtqz66QClq+w2m/ho0cLjMQOcGC2PKVvN/Q69jNt273ZNF1nh09wt6YX8xO7z0U6ywvn5SuTP8xfSD3vRV31HVrhgqr8c10SxXxapxPl/1w20CCCyBtgaCjwA1jFcR2Qh995bbpZVFd0Gy5WK8np5+zCKTfL8398WIku41u1Js3it2ILmB7iC+zourlDR8cb/A4fICts=</script> <treescope-run-here><script type=\"application/octet-stream\"> const root = ( Array.from(document.getElementsByClassName( \"treescope_out_0da14502c8034ea08121d36f6e6019db\")) .filter((elt) => !elt.dataset['step0']) )[0]; root.dataset['step0'] = 1; root.defns.insertContent( this.parentNode.querySelector('script[type=\"application/octet-stream\"]'), true ); this.parentNode.remove(); </script></treescope-run-here> </div>"
+       "<script> (()=>{ if (customElements.get('treescope-container') === undefined) { class TreescopeContainer extends HTMLElement { constructor() { super(); this.attachShadow({mode: \"open\"}); this.defns = {}; this.state = {}; } } customElements.define(\"treescope-container\", TreescopeContainer); } if (customElements.get('treescope-run-here') === undefined) { class RunHere extends HTMLElement { constructor() { super() } connectedCallback() { const run = child => { const fn = new Function(child.textContent); child.textContent = \"\"; fn.call(this); this.remove(); }; const child = this.querySelector(\"script\"); if (child) { run(child); } else { new MutationObserver(()=>{ run(this.querySelector(\"script\")); }).observe(this, {childList: true}); } } } customElements.define(\"treescope-run-here\", RunHere); } })(); </script> <treescope-container class=\"treescope_out_9b2ee383cbd84a908bc3606a4543ce35\" style=\"display:block\"></treescope-container> <treescope-run-here><script type=\"application/octet-stream\"> const root = ( Array.from(document.getElementsByClassName( \"treescope_out_9b2ee383cbd84a908bc3606a4543ce35\")) .filter((elt) => !elt.dataset.setup) )[0]; root.dataset.setup = 1; const msg = document.createElement(\"span\"); msg.style = \"color: #cccccc; font-family: monospace;\"; msg.textContent = \"(Loading...)\"; root.state.loadingMsg = msg; root.shadowRoot.appendChild(msg); root.state.chain = new Promise((resolve, reject) => { const observer = new IntersectionObserver((entries) => { for (const entry of entries) { if (entry.isIntersecting) { resolve(); observer.disconnect(); return; } } }, {rootMargin: \"1000px\"}); window.setTimeout(() => { observer.observe(root); }, 0); }); root.state.deferring = false; const _insertNode = (node) => { for (let oldScript of node.querySelectorAll(\"script\")) { let newScript = document.createElement(\"script\"); newScript.type = oldScript.type; newScript.textContent = oldScript.textContent; oldScript.parentNode.replaceChild(newScript, oldScript); } if (root.state.loadingMsg) { root.state.loadingMsg.remove(); root.state.loadingMsg = null; } root.shadowRoot.appendChild(node); }; root.defns.insertContent = ((contentNode, compressed) => { if (compressed) { root.state.deferring = true; } if (root.state.deferring) { root.state.chain = (async () => { await root.state.chain; if (compressed) { const encoded = contentNode.textContent; const blob = new Blob([ Uint8Array.from(atob(encoded), (m) => m.codePointAt(0)) ]); const reader = blob.stream().pipeThrough( new DecompressionStream(\"deflate\") ).pipeThrough( new TextDecoderStream(\"utf-8\") ).getReader(); const parts = []; while (true) { const step = await reader.read(); if (step.done) { break; } parts.push(step.value); } const tpl = document.createElement('template'); tpl.innerHTML = parts.join(\"\"); _insertNode(tpl.content); } else { _insertNode(contentNode.content); } })(); } else { _insertNode(contentNode.content); } }); </script></treescope-run-here><div style=\"display:none\"> <script type=\"application/octet-stream\" >eNrtnQl308iWx7+K2n1mSAZiapVUockZJ2SjG2gI3dD065Op1RaxJSPLWXiH7z4l2Vmc2AmxYmH7VeCAI5Vqu/+6de/PsvVLLztr6416lmrdk0lXH6ZJknn/9rpJL8qiJF73Ut3mWXSsn3kmibM1wztR+2zd6yRx0utyaY+ftKJMrxW/rHvd1B5pR71srah6LTvr2qNxEtvDgsujZpr0Y7Umk3aSrg8ufeYNfxNtW8DWF6mste6ZKLPF4kzH2TOvE8Vrw+MQgP+ydSWna73oaxQ37XVJqnS6Zg8987pcKXtwra1Ntu4h2cp7E+u1lo6aLXsE1mneXpzxyA7uov7hi7XjqBeJqB1ldoi8nyUXZdeiOEujuBfJvFk9ODsc17dfng7m8ZeLeVxL+7FtM7XHejKNupmXT8TzR7zbbUeS51P7NJGZzqcp1bzzaGNlZfX5hp15214v85Q2cc977mWtqFdv6uydNcvrROmV1Xor6WX14rwdms68w66O8yE3ZF5rftHf/4w7s8dj1db2dNxvt58NWqjbbh4kSWyPrpwk6dGqd7UPyQd7KD81cjiLZH6wq1OTpB0eS12Pk5OV1UIItoGVG2e8tcFFv3gYrdp6IuOtXOt1va3jZtbynj/3QF7k1q6nOuunsZ13T7d7+rJjrX6c9+x61b1WZLK8f0WB/MU3+2dCCytWfrFKTuqp/tLXvawRR53CXDsp7+iVwZys5nU8u9FQt99rDabx2ZgxnjfxfDCMW0b5/X3IezEwZJY0m+3B8j0slphVazevKz+i29kTTx9bgQ8tmfeu+L1+pM/ySa+ltbxDw8J12ea93m92FQ/rXald1HnYsTKsnTf+bdXOp5V/ofGNX56OWwAqOvaKCp/XRv1Mzcu4sCPVp89roGaXbprdLJLEtot2MmJ76rbFMH4GVvJrzsdes4tx4O8Kh3PIhUj1caGfwv/87IeIA2BHNSwgk07HXnilBC9+8sFfK8LX4yRbWW8lxzpdHVN+WNyOxQpEXakR2B9jLkvE/Y7Q6dUCLITUvyzQy/1Q82qfMKSQ5gXsROg01eqwaz2pbiVtNVITD/I/Q0dezMS6F2XcOqT8YmOLc2FnMLZTO2ELsMMeKXY4mHRbWkU92+jZuau/XtDb8Npc6Pb6utDWOegrvZLFz7Ox7Q28+BrM3fjQ/VvzXLQVxYVvF+0k3zcmtlkY5WbLiqdHPc2bVnDxzasLe1471OK9lY2izo2x8zDQgGxpeaTV6qr3P6uXfcgvHX/RefmRHhbb0br36F+ICvnoR3Zv9KKJnfQr6GRux7zhftrLDdhN7Kas0zHtRr2Ha7ZYCkVDa4Ub6U3S+MO0ejm8TJ9mN1upR71DE6W97DCJD3P5j1laty2lOqL5ahprKq909wcWv97FfFQdnjZtGDXoRrGgv5VszfrD7pnoZ5mNX8Y5oMvT40Rb82rXStmJtEHs+ML/0pCo2rUY+NErblUR8bZ3cNYRSbvnveln+XiVtzW40v7fPbMLY+1EiyMbzw48b8duUa0icuVxZi+PeE+riyj4Zw3yP89uynxwdRF9gjrTneujHKyPMaMY7+4ur6yf8N6htPuAndiL67nJRnaPcz99W5vXrhlt8urUe8c8XVlbUzzjazy2hi3im9Wrh/NG8qAt5fG5motqPdjztJ0xG5GvJf3sfkO56IE1TKTVT6M9KZr0foo63STNeHyjbpEmRzo+zI9cOqO7Z/fKZVfm89zM3+p5CGQ7pg6lDaBVquNhV0dTFFvnaMEH8q5Xls5wIx1ZqpK35YrNo2wQD7unRdxX72U8v/6ivzPryTCzG/REJZkde96Lq5P3pc/bsQ2LD23maaJTW8nIMgmLZWJzAJ7HRSc8je3COzx37Oe2MIZLiMcU7Nog+t8XSWU6zCFz7zWcpOGhNVAv3Oplirte5J08XWumXEXWbCsexFTp5hMvsZJuag/Y7vmy9WQgcRv95g6jOOQNp/lGX2541odx294NB30+nm/1k5aVbh4pj/Ox+ZZnHfHYMoPg7Eop2+qkigY1WGu0edf6wrvjyftvFpNbuOzooJA+tU5DTSzzEP0Y18TIVFymcOOmYjRHqo/mZt4tNVwfajySLY4v+D2NTaznAQFJnrN6PzXSlJ/VTZp0bB4s+3nuVc8XfK9+zNs2WV5ZXa33EpslF24gz3bz/+uDLTvPdL9z0649soti9YIt9FpaZzmA0Cfe1sHBQT6ag/xYjhOKkzZZL7Kug7NYrvzf/w4DBanPHdL9g4araVqcA5X28NjJkGWRPFftpXLd66ftlXwHW8/PPz1JjEHPhN0jffJEAbb7qtnYbBQ/+28bjaR4tfnuxP67t9NobDdu+9nsNBrNo+RXtb+9uXXyV6Px/q+tl41X+5tbjZ3m6f7eb62st/kq0k288+Ij+m3f/+v4oNuPfn9F38OXH/ff/fnq+MOrr9nvZzs7W48/NI/eR5svQCt68bb/clvtfgZ74qk53lfdL7/6rS8fouht/1W829ozf2SNP/zN1ylp7OzHR9u+/KPfjx+/o19k7+jk2Oy0n345bW4nYVO8PNkN4V7jadx4R39L05fw3ePmV/BOgcZLA5uvg62T3c+oCZKz/rsg6GxD/2TvI3vTbHb1+6MzovfFVypF+mY3443m2/3XJy9476z3tr+///HD9s5J4/e33f2/1B9Pnz5uBu+DjzgD5tffvzSOqa3zt8broPHqpNFpfn138Lj/6UBvfzxFxpdfX5N3e2e0v9n49evm5+5OF0d7b7e2waf+7+QgiM3mb9t7O686jehxeLyNWjFsBY/FnycfP5/spccvdv/Yij+b7e1m9viN/NRuB5RtvTzZDFuMvHq1e4B3PzWanX36efMty97v6j22vbm5v4tfNMm7p3/JM9HYtTb989enjbe7vKFfbbUbe1+33zQ/ZU1/8/fmmzf7LzaPordU72x+3NrckRHottKkG1ttdD9tv4Bf4dGB2TJZ6+zXeE/xnd6eAa87u9uv/U3V+PLnn12e9Q4+dZTiEUPmKyN/RJ+/+N1O6r9J/to6iNLdzvHLXXzw4QDvbCO5+da8f7zXTrq7ZKd3Qnnzix9Gn/TB63b3Q7y5t6/Vq1T3P3zZ3erADzvp0cHBKUX+hw+9k4bt0apXwMRs5VEh60f51vh/9p+L1c9V0rVxweWSLBBovV6/pcSTwZr9x9Z1O1RqFUyuCN0GUaWt28ojlt7KILgbJaZ2Cb5P8uVriw2Dv/xYz7qHvIo8ms1DQH7Co8yL+XHU5FmS1m3NXZHwVNVP0ijT723it3JZlx3ssK5LLGcDkpXalVA3B3K2lfdRR9uYeOWc2N64LtUdG7feuPTbEw8BAIqwwzpfG4GsFEnb+HavxLO1y87l6eq5B8sZZs372dvhUds6tizx8sI/FZ7NBhqxjdmsN47snGmu8nD88dW5G8LFO7BiHtqfc8VR7nM9SKpt/DLYoX+J4m5/uNPUij1ZJKe1sZUMt297crB1204UF4+2O7rT1kZPXotMaxt2vF39JTe43f/tHpCLk7cLhdTtYO2lG8P/ti/O2xk1UbOfFjviyi9PhwO50s6j87jq0ejh/NBh+7g9erh2I9mo3Xa+tvGlL6Ks93zydD/o7P49doSXudQjL4m3ct0+f3TPhVuQ4NVH3kWi97xWH4yt5hWb7PPalSzQ7tPDs3n2fj1PtWcLoVpH2LKvhzO4MWrDCm1U0Vqodg28zad/Px54/4nin600/gb/3K4OW2ARBNKPo2x0CV99L6G28d8/n6Lg2e7e18GLYQef3LTzRQJV2/DGDKM2kt3UKjZVPR/mnfYqSk1vtIkmHO85DyN1Om7mB2/z1DbAos71xejunvCLolXMOo9bPO0kcSSj7Oy2mV8DdbSokz8yyLsNMFK8CiOY4p3rWN5qAFq3ISddVBNcDPHu6b8oWsXUqzQ61rljL26ouNX11OGiTv7oIO+2wGj5SszAM333josAomsgXEOBB+A6puvIH9mBb5vyJ3NoFjvo7zCGLfVQJrjLLo8u0PS1CGrk7g1rjnY2ds6v3ihS2/A9E+m26tXr9cmFL+tsXtY5+G91Ic06wwj4RxoTerqtCz40pTX/WUTvOatk9/s9Y573yUHVhwNmf1i8yzcjxPCD0MKkUU6a/0nlHX64J364QIUFUygKHfazqH3l1/zdo0Oe2fLW8rq3MnGFzojsDe38Z27mWxt9Mtl5jLzjVtu4GMM8aPyWPeOWSxZB6VEc5Tfs2Cjuu8K7x4uIU24xUX1k/FPYeLSCKnabRPR0epz7krvN9XHZzHU5+GlsdXn1DwkLxtlrePt0beN1EuvlsdONc9OY68a5Kqw2sp6PbfvJeRwXqee1i/vRBWc+AVphCilhMGSSCAQJ4oJKAXR4ze2Ou499GNaP9/Wf+Wm9uDPEuyNtsAXPi9jIvtvWpz5ZQU88uHozvl82fz0wT2mvPaimSnHZo70oOzvscOuuT8fqC9MQEBSyIGQk8KVQKJRMBdJnUiBGfri+0HLra9RCZSQ2WlO1EcItAmMohKHREDBfEEpNyDE2ghogACCGgLkU2EJgpu+LQEoo60Yl/9nscfG9TqW55ff7EUdBHAUZkR28v1LhMlKQtaVKq2FZCgIdBanWXCUoCHQUpDo7lacgcL4pSOAbGkoSGo4pAUwwg8JQSk4Z5lwi31GQCvz1lBQELgAF4Yr5imGofQJJIHGoIJA84IBCZAwxjoLMVl8lKQicewoCKZQUUYB8QAhnhBmFKQiIVIAogbmjILONX0ooy1GQpaIgFeeWjoI4CjKlUtH9lYqWkYKkS5VWo7IUBDkKUq25SlAQ5ChIdXYqT0HQfFMQhqVgwnAisSBEB0whSKWUVKn86xcdBanCX09JQdACUBCNsSJQUSaNIhLJMDRU+VQFQvgqoO5ekBnrqyQFQXNPQXxMQp9obAAzVmBMCM0w4sonTAb2gKMgs41fSijLUZCloiAV55aOgjgKMqVS8f2VipeRgrSXKq3GZSkIdhSkWnOVoCDYUZDq7FSeguA5vxeEGEolkcBHPgFGM8B9owNoAhZSAKijIBX46ykpCF4ACiKVAhwzFQgKiDCIYawE94UxSCAcUkdBZquvkhQEz/8nYkIIMWdaAwUJ5pRxAaRgOjSB9gF1n4iZcfxSQlmOgiwVBak4t3QUxFGQKZVK7q9UsowUBCxVWk3KUhDiKEi15ipBQYijINXZqTwFIfNNQbCUQGgcBiBABADJ/VBTjKBkOBRKSEdBKvDXU1IQsgAUBBoqJZdCSBXmb9ozyEI//xSDpnnSGjoKMlt9laQgZP7vBZFB/kGrQCnFSGAQZwE0PubCl0ZApBwFmW38UkJZjoIsFQWpOLd0FMRRkCmVSu+vVLqMFAQuVVpNy1IQ6ihIteYqQUGooyDV2ak8BaFzTkEIN9rn2KecE0q0CAlGvlGCKco0hI6CVOCvp6QgdBG+HdUwFTARqEAyQhBmCgDADWJEBoj52FGQ2eqrJAWhc09BQCCBRkBihQzRRnENJeQEUd8PFDXQUZDZxi8llOUoyFJRkIpzS0dBHAWZUqn+/ZXqu2fEzLv/8ctSEH/OKchfy2auEhTEdxSkOjuVpyD+fFMQxH2oA19RoDjhCIfAGIND3xfM/g3cvSBV+OspKYi/ABSEMSIY8qXGBBIKNZfCFxow6TNqc1flKMhs9VWSgvhzT0EI1ogh6AeIBiTgNKQSceRTJWQofI4dBZlt/FJCWY6CLBUFqTi3dBTEUZAplRrcX6mBe0bMvPufoCwFCRwFqdZcJShI4ChIdXYqT0GCOX9SrpQYByS/8UMSP8RMSqBpqDDwdQi5+3bUKvz1lBQkWIRvR+WBBJhQYAAl0iapRoLQaKYgBViG7hMxM9ZXSQoSzP8nYqChWoRa+j4lQDPOISIB0VQElHDDHAWZbfxSQlmOgiwVBak4t3QUxFGQKZUa3l+poXtGzLz7n7AsBQkdBanWXCUoSOgoSHV2Kk9BwvmmIJATn5EQYO1LogwIfQRUqHwGkeIhVI6CVOCvp6Qg4SJ8OyqS1A+NJiGGJGQBwzJQChqfAIE1cE/KnbG+SlKQcP6flCsJ8QUHlGpKAhYyppgEATSIC0AgcRRktvFLCWU5CrJUFKTi3NJREEdBplQqu79SmXtGzLz7H1aWgjBHQao1VwkKwhwFqc5O5SkIm28K4lNfICG4YQQRE9qXoSFSmBBw+4piR0Eq8NdTUhC2CN8LYoUUQl+yEALCMObczz+DpQQiADHNHAWZrb5KUhC2AN+OGiIVAkCMlETBgDPFDMBAcg4o58JRkNnGLyWU5SjIUlGQinNLR0EcBZlSqRDcX6r2GveUmDn3QNZGJUHIjRocCZm1wUqgkNHLHQuZsaXKw5CxtcwRDdEsMGEIKQUkIEAFHBnCqM8pkIEQwtGQSrz2lDhkQj3zxUOUCkgQEgx8QwjyDQtpSIz9IwMIMESOh8xYYSWByOSq5oaImFBjxqkRYaiJ5JJJ3+dQo1AIoIBx94XMOo4poy3HRJaKiVSeaToq4qjItFqFU2gVuqfGzL0PgqWpCHRUpGKDlaEi0FGRCi31AFQEzvm3puYJBPA1I1oSgZEQDIT5l1tKwwSdg4RiKakIfCAqAheAimCGqQmN1lgQopjhTCmOQhgGMH94jHZUZMYKK0tF4NxTkUBJoJUJUfFYZqF5SIUEhksrvBAA9xTdWccxZbTlqMhyUZGqM01HRRwVmVaraAqtIvcUmbn3Qag0FUFzTkU+LZ3BylAR5KhIhZZ6ACqC5puKEA2gTSg08oUgzGYTKsAh9APDBQnYHHy/w1JSEfRAVAQtwjeIaESEJhJzjoiiWigshX0NFGZaB4GjIjNWWFkqguaeigimQopD4/tcEkKNIACBgBkOjcBIakdFZhzHlNGWoyLLRUWqzjQdFXFUZFqt4im0it1TZebeB+HSVAQ7KlKxwcpQEeyoSIWWegAqguebihhFgAEYYRAEBELGgA94YCRnEmOD3LeqVuK1p6UieAGoCDQUUiW4RDwkoVKcB4hxI42QHDHsni4za4WVpSJ4/r9Z1TAKoJI6QAEJKGQUw1BrhKABgTbIUZEZxzFltOWoyHJRkaozTUdFHBWZVqtkCq0S95SZufdBpDQVIY6KVGywMlSEOCpSoaUegIqQ+aYiXBMZ+hphpgNCqGRYqxAKiDCSQnD3CZpKvPa0VIQsABUhSmnJQgo59+1rKQglgMGAh0HgK186KjJjhZWlImTuqQgFCoYqoIIIRgIEONYQSKp8oANujPsEzazjmDLaclRkuahI1ZmmoyKOikyrVTqFVql76szc+yBamopQR0UqNlgZKkIdFanQUg9AReicP4HXZqwCEsQEFsT4XABg8wrJqT0omGCOilThtaelInQRvm2VSIRUAA1GhgCiQiMYUEHoUy4g1MJRkRkrrCwVofN/r4jVVMigIYxoIinh3FAU+koTzSVlzFGRGccxZbTlqMhyUZGqM01HRRwVmVar/hRa9d0zaObeB/mlqYjvqEjFBitDRXxHRSq01ANQEX/On8irCEHSp8T3OQmFDKkIMVEUYWqMz90zaCrx2tNSEX8Rvm3VYAM5wqEiAfGlCYNQ+YYS6Gurszn45hq05AorS0X8+b9XJH/cs8+QEkISBUKhtDYEQ6wwIgpSR0VmHMeU0ZajIstFRarONB0VcVRkWq0GU2g1cM+gmXsfFJSmIoGjIhUbrAwVCRwVqdBSD0BFgvmmIhhrEWr7K9aYQAZ5IFXgK04VCAiWjopU4rWnpSLBAlCRQHAVKOwzTjmhOOTMGG7VhpUEhnL3ZN5ZK6wsFQnmnoooEWhjQgC0HxIEVRhg31BNECXYMOI+QTPrOKaMthwVGaEiCy+LavPMH2lyGHq6rfMrprb6P8ux39zX5lXsHF2e8o7OdHqYg6He88lM7EEQ2N+Vgp5rg5s0/9eKLQLOqRpd/lC7/T35MeY3Sy6c9cbRnKylM76IROemPe5lvL9/wMPnx82/uD79CxFvjJlPeJ/JhwsaYaAHCzAW1MxVeMcfGkKeG/g/JICsOm75fs8puDzSsSoavPtNCcOP9OHFe4yHme5li7ipXR30JFtcLVOFIXqtJOuNs0Dc74gc1EAAwGJNczGkSfNbnKxiYrc//r79bv/V9uv3h/sv7L/7O/vb7+6W+qJqe+xwJxlhbOGKjfK+sXuwXFnqtcF9x+TnxZYjz7m+ahYiALtmiVsCsJslXQC2YF6xkiX5/Z5Q6Z5Mo25e9d2b0q6Odcrt1Z5JUm9Rt6grQ55kiCtFqjHCcSRtt8+k7XwWdew2cmssBuro2s+iWeDmeCeb4mbZSgJi/aWvY9uy6qcDlK6y22yC0aKFx2MGODFaHlO2mvsdehm37d7tmi6ywqe5W9IL+Y3d56OdZIXz85XIn+dvpB/2oq/6jqxwwVR/Oa6JYr8sUonz/64baBFAdA2EayjwAFzHdB35C7n33nKzrKroNliuVJTXy9uHUWyS5//+thBZwrVuT5rFa8UWND8gFdzXcXGFio43/h9nzA39</script> <treescope-run-here><script type=\"application/octet-stream\"> const root = ( Array.from(document.getElementsByClassName( \"treescope_out_9b2ee383cbd84a908bc3606a4543ce35\")) .filter((elt) => !elt.dataset['step0']) )[0]; root.dataset['step0'] = 1; root.defns.insertContent( this.parentNode.querySelector('script[type=\"application/octet-stream\"]'), true ); this.parentNode.remove(); </script></treescope-run-here> </div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -97,7 +97,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"display:none\"> <script type=\"application/octet-stream\" >eNrtXd9vG7kRfu9fIfiA1m5iHYccksMkZ6C9a4F76UP70IcgMGbIYeyrTnJl5ZrgcP97ufLPdewsmhx8jULBsLTi7O4s+c3oG5JDviinP83ON+8W+s1eOT0/W/C7Z7Plaql7s9PyzV5drY+LVl2vtRxj0ghMQRgKFgEu1hHmXHIwVZzuHb04P+Nl+z9c72ieV4t2el79+KMuN8f/OdHlsb5tAkXLs+Vqsz+vq0VhWejxclX02Qmf7x8tWHRxNC453qxev17o9pxn+UTzv7QcHMz+eDD7eba9x7PZV7x9PZ/98uLri7tvVZnlBZ+fD49x63JNzYu7vDhdnr3ZzDbvztrDb68rq7d7955zqUIrvLj90YuvtyePb3PxwCyy1p/27iu6ty7uSG7LmviCz86Hwt8vNs/bQ11U7F25m2t8NbtH6A+tyrb6/OHoB347/9N6ze/uldte7FrwSqSpe7bQtwH37dMZHDxw5YnrPaj77Wd8ffOMd94um+oDTz4qO23fLTcNrPnkdFHWuvxg+d7Rtkr2X74082gimBDjEzP/4dXT380uXncLXj2dlS1gruvm4AHFx2/NzI5e/A+2JuxDUhM8RkHxJFiqgjiOxbJwurG1DvNfFeZ2x2GOafvaovnpbHw8gv0HBR/LDBJjJLWViw/NDGL7CyRRuBkCgetm0M3g48zgAtUwvwN7mF/B/VFhntWp9ZAlh4xSnRAQFTYsCW0Q6jDvpOYjYD57kNUc/ka0BkP0sRRP6BmFg9jk0DpfyCSrATvQuz//OKCP6crhzReH7yF/LPpbUZvIyUGSmsQ3ExDhxnGSOjTaVAnYqU03hV2gNpQrSE7C0SAGbOzdem+EM+Tsc2fwndr8Cv01lxifjQLYqy+f3Mg+YuAqjbybxubJKHoInJIUmyDGSibGzui7d//0/psrhA9O/erzLX7zw0PmcC1wt1/n2o4ejQSlnMETB28VOahYBPLBE3j0qZpuJt1MdoAEifhIDc4sIWFBTAbJVs2YSzCQbId5J0Gf3r9zDws6HP0wPD4Ncs5LlFxi4YRqTEpsUotwWaEE34exun//Nfp7bnjQ4f0850GLuMWEPkCFtq9HsRdIaiBH77UMI76xxQzNYNgzZNPMpYcN3V52YryrVERUXzERVikCllwmE0IWF6j/LHQ+9DEwfw/ejwxrhhCAg4NsG8dnEOO9RwWyKF5y7bDu3vujYX3tpO/C+9G9d0wVsjeRBBz6hCkD20rVWmLwIXSYd5jvwshVaiQl58xRFBMW8dlV5RbPqnGlz1XoJOUTYP4evB+Pe2dN1tfEiQkd+0ZOQFMgMtZCLq7DunvvT/DeD5KUR4a5hmKUJFhoFDwWbCFmJRKnoZaG887FO8x3gaREWxI3oJcSIhb2AkRkyRdNDfK596R0krIL6VBB2OdSOCoGpEZWWF0h7403BOR7v3j35l9EOlQLP22C1I4toncSi0lIBkASaIFuBt0MPm449Xra/CGMgD8UweU0+cedMjPMEgCjNWjGCkqBa8yUc0rkNPWZYZ3Y7EZKVPWUwXqNXAh9EsrFG3QN5MWFhL4Dvfv0LyQlKvkMzdNnwwURTWimIMoWjHORgfs0yW4Ku0JvDJaGaa42B0FxxEDIpJWrgJiaO9Q7vdnBtCgCYyhxNjY7VK2S/TALXmNNgiHFDvvu4Xta1HEhsBSztcXhkBBOropr3KhgVXXc+3m6mewKEeLiBJmdtQ3qEoCCUTHqqnUy9Pd3qHcitJOpUSoqBUquRgmDo6TJe8wGbMnNAPr0su7je2rUbU5knMaAaF0aaBCJYi42A1mJDJa7vXR72RFOVH0j/4zIviC6GpKjimFY+BWZwPV+0M6JPsf0KGs1xcAu+hbIUknkhzwpJV+NCz50WHcPvgvpUdmXoEmit8Gi+iDi3DBTTUgSxb7YR4f57oxieaPNc0MwjZokgQQ+lMZcCErDfOycvBOVzzFFKqGzpbESU5gxCrNLVKKL4A0F5p7g2j34LqRIRYPBGhxW4gD0yYp1Gj1zNlWr77OJO8x3hqhYayMmdRWxhZ7MKUFj4sGb5uNNzH3eQScqu5AmVYsDdC0AzZGxFhAj4LINiUghSx9T6h79S0iTqh6ruiAUyKEGoAKKpVpniGuV3gPTzeCjiM1VT+P7DP6G8zwyh7ecnUnBC8SK1gRiNFBDTKYQkOmJsZ3Y7EaaFKiaUhmLq4QlFkLOsYApGpSg9Hli3ad/KWlSAuBNcOg8G/QZUxgW33OxVldzTd0UuinsCr1hMpg9kFZBbJBPYZgdmSwlY2qNvSe+05tdTJMKYBQ0mSCWEawhJ7lGn2wlBux7A3YP39OkhpgAk8/sgpFhzkGxDNVlz2zVOobSpx90M9kVIhRtzkE0xACAOTj2RYLwsMFg+wc9X7wTod1Mk/LO+MgaisWCFiwRGKg2G+tAiPrIbffxPU3qdsQcUFKOKCjtk3dC6JyHMjAj1/Npu73sECdST4ELFyCDzIGztyGxKxJjiwo61Dsn+hzTpGod9stMzNUn9DmJEwWoUaNqMn1It3vwnUiTaoEsYPCNqqhFG1slGMg1B1+rqb3zpsN8h0axYs6pYKw1MFIy1Px7IGzw52Gnhu7RO1H5HNOkKGcQzQLVe5QIlI2veZhhSc5o7Pkj3YPvQpoUxCTA2dZYsHEVGTrcbawQbCrqbZ9U32H+f01UNmvV87w608P1m+Xhia61KZjXp2dXQOSzs8Vp5s3pavn1Km90c3jezuEf91pzLM+bFK9f6+b7cj77ZvZy79ouMDUfzxSEoWBpJlKsI8y55GCqON17OrsRFvYhqQkeo6B4Gna3VxDHcVjWhtNIODFGUlu5+KEPM7a/QBKFmziBGwtndWo9ZMkho1QnBESFDUtCG4RGwhiij6V4Qs8oHMQmh9b5QiZZDTgSjpwcJKlJfBMS4aZPUjcsyJlSwLEalCtIC9Y5GsSATV/rvRHOkLPPd3RO0tQzw+CdUfQQOCUpNkGMlUyMY51jar+zvnkdbxU5qFgE8sETePSpmnE9t7qi9iVLSNj8VTJItg5r7JZgINmRsHO+1erQ28AJ1ZiU2KRh3w2FEvydRoE0BGjRey1D48WmcJNmz9B+9jmNdZ7c4P228OS22ePamNh8eNQoU1u4jnSe2hjztvDk9oIjnac2abstPLnV1QhIUxsCjbAxtaXKbeHJbSlGakwt3H9beHLp81ELTi0YfVt4ctncEeqmFh4dNffUYo0jNaZWqrtTzx9e6+u28OQKSiM8T61DM2qUqZU8Rs09tT7CCPxTWebjB5zI0x1V3VS247ieJ3LCRmpMZdWMHONUZsLIBqfmbo8gOjX7deQ3puYMjnSemjk1dl8Tc09uC0+O148ecGqwcqTG1HDPqLmnOtHHVTfRFTnSeaozZ8wKJkLkUaNMBRqvnl8QsrLK69Vq0+jY5uT0fN7I2d/b4d9a1LB/8Hx2Sdoa67sUuhSf//uNrt/9QxeaN6v1/t78mhgeD8V775367aIFRMNNLo/nefhie5vN+o02+euStbYQKus/Tzcn+6PTry9a1/x6iEQu9HkzfJznxjI3+t3l4V8vJYZnuJKeN26qy/LtQJ2vLzyUr9az/YVuZqfteuZ5e3txQ1PnC12+3py0b588OZj9PBvkLgqb8PWV2+FfFjp8/PO779vFr85+efqq3WA453z1Zp31uxYpPliHXw2R4t7syezO6ReHo2q5vtq8nq7Pr+69fbJ2wk3pWn9c/bRtyF/GLXFvJR8MUcyWzDe6fw/T/y9c5y+7</script> <treescope-run-here><script type=\"application/octet-stream\"> const root = ( Array.from(document.getElementsByClassName( \"treescope_out_0da14502c8034ea08121d36f6e6019db\")) .filter((elt) => !elt.dataset['step1']) )[0]; root.dataset['step1'] = 1; root.defns.insertContent( this.parentNode.querySelector('script[type=\"application/octet-stream\"]'), true ); this.parentNode.remove(); </script></treescope-run-here> </div>"
+       "<div style=\"display:none\"> <script type=\"application/octet-stream\" >eNrtXd1vHLcRf+9fcVCARqqtCz+GH2M7AtqkBfLSh/ahD4YhDGc4ltKzTj2dExtB/vdyT58rS15UDpT6zLOh2z3Ocknub2Z/Q3LIF3L80+xs/X5Rv92R47PTBb1/NjtZntSd2bF8u6PL1aFUratVlcNCGMFU8cEGQJuRoTgLjkrgYmreOXhxdkon7e+Q38Gcl4t2OS/fvKkn68Ofj+rJYX3XBKTKs5Pleneuy4VQWdTDk6XUZ0d0tnuwoFIXB+OUw/Xy9etF3VzzjI8q/7vK3t7sT3uzX2abezybfUWbz/PZry++Ob/7pigzXtDZ2VCNG9m1Yp7f5cXxyenb9Wz9/rRVfpNvWb7bufOaiyK0xPPbH7z4ZnPx+DbnFaZSVvWnnbuS7myLW5KbtCa+oNOzIfGPi/XzVqnzhr0td53HV7M7hL5uTbYpz9cHP9K7+Z9XK3p/p9wmsyvBS5FW3NNFfRdh1z2d2b17cp7I796y36zj6+s63vq6eFQfqfko7bj9drJuYOWj44Ws6slH03cONk2y+/KlmSeTrIkpPTHzH189/cPs/HM74dXTmWwAc9U2e/cUfPzV1Ozgxf+iaz5kAy5jyggpchGXGSVxRC4O4VrXOsx/U5i7LYc54OazQfPT2fh8BPuPCj6WGqDLNmu1BmOBEDST91qCmmIMKJiuBl0NHqQG56i281uwt/NLuD8qzFPUkBmykg9gsKC6nJkpoCdiFzvMO6l5AMxn97Ka/d+J1pBgFPS2RrCQ2GexhimRCdapgnagd3v+MKCP6cr+9Q/7HyB/LPp7URsbLAcXjIsGgBBQm2NtErAYkOKpq0JXhS2gNui5YFEC9gWgJhRnAzMHkezIdGrTqc2n99dcYHw2cmAvf3xyLft4sK/eC1gJyCrAjnPWIDFIKiVKCr3/plv3T++/uUT4YNQvj2/wmx/vU4crgdv9Old69FhqEj3kCNWrQW1qgqVU9I4kAnKjQq6rSVeTbejfAQ2BgU10EYxWNBS1JqsJczAmdJh3EvTp/Tt3sKD90Yvh8WkQixjy2GhPMFDUYaNFhWJRdcX53IHf7ftv0N9zzYP27+Y592rEDSb0ESq0+TyOt5yt9YS1GrHgKSAV0/znmjXVaEIf7+r6sg18yDObUn1uLyQHxjDFXIN3ltHnIoU7zDsfegDMP4D3I8PaamAmLoUlD34tWsxx6OevYbDmucO6W+8Hw/rKSN+G96Nb78hpGLpNIoKQ1BE2TzZ6KpG1WCcd5h3m20BSgLRG8jEQQYBaMngXVQpKwGpth3knKQ+G+QfwfryZxYqSsCRJjADOoxhjSB0CJ4fRd1h36/0J1vtekvLIMDeJTXWGvTiFqkLVsiVwIcYkQbv17jDfBpLiKNqaogQjBOR8Nqrqc4wF2//Ue1I6SdmGcChEKOgiVw8Wgq3EJZZqkCOGZuS7y9mt+ZcQDgW+OnQ2JhcSJAo5sCMXgxTOpbmqXQ26GjxsOPVq2vy+HQF/SLIX0+Qf101l9j7B0NXCELNHbnw+ZPEm1mypzxvuxGY7QqIqNU/VQzBqAnCz6coma0WxwXjOfdCo2/QvJSQqWg215MoxBjAViayDBDWUFIAUuyp0VdgSemMJIkI2vkYGUZOjM5IlonVC2XaHttObbQyLYschNnYD2VvImNBzErEawRRfTY//7ha+h0W1twMDxEImhBogYUYU5Kas6qgYsD16sKvJthChGGJxpTR2Dw40t8OswEWzoXYUepdmJ0LbGRpVGsKzjYzZGkDvieIwlivFgXFYu7PbbXwPjRrNOs5O8rDsHzeP2SZqnEiNN0yNJxGVri9dX7aEE1VMmrMNwUACI4mcAoZIwXAqpXRO1DnR5xgeJZIgZfAmKoCLijlk0PaPG/fyti/20S34NoRHaa4eKWjJuQITI8dItrpcihGjvfOmw3xbiIoboG1iRagMxbtS0ORhdiYrltCh3onKZxki5dEHzVrrsGRl8zKbqyk0rESf7BAhVTusuwXfghCpJGyqaHab5QlKpRwKGyVu4M/G9DkIHebbQlSgGtugXl0sBZrfWST5bGNSKpCwzzvoRGUrwqS4OijN6fREDiTUIp5LOzbisdaUOsy7Rf8CwqQKSg4+a3NOGSBoAeNMajzeanNSufP3rgYPIjaXPY0fMvhrzvPIHF4FjBrvvEkJrEU00VBSJmTvta/F1InNloRJWQ02SCF2lCGLECWHpKyFyaHvYVLdpn8xO0cpBmOFa3IJUrAYvM21OmfVpKp9HLWrwrbQG2rObI7VNfc1NSbP6KtkW6xrNL4U6gNMnd5sY5gUiFTGHCxRbMdcYNgW1ibKKUWJfVWnbuF7mJQcBiM2SwoFCkJyhny1hoNEUxOpdue3q8m2ECHb3gfFgsPiC2ikYkxDPFNoPxYsPVqkE6HtDJMads90kqx6p2BAshY0knIMVKytPeyj2/geJnXzRdEUJKNVQGi+cwAiDS5HqVCJA/YXRdeXbeFEUQAcxwAxEuTCOZTsQYLzQbWvhtk50ecZJuXVqx2W8hZIEFlzyhI1gI21gbvPVesWfCvCpMKw7kFEJ6UwiMlFalXw1ot3ILZvDdthvi1ExfthVct26of169FSYklRKIhJ4LkTlU5UPscwqVRIkviIFAiCz4Sq1CDuhY0G6vMQugXfhjApKamqZmNqzOCs5OQbHa/gAnhF6KNMHeb/10Rlvar1jJendX/19mT/qK5qKyCvjk8vgUinp4tjpvXx8uSbJa/rev+sXUNvdtrjODlrUrR6Xdc/yNns29nLnetZ9oQRTBUfbAC0GRmKs+CoBC6m5p2nsxvCPmQDLmPKCClyEZcZJXFELg5hJIxDrK1WazAWCEEzea8lqBlGvRTMSDg1ZcwMub16hkkSBdXlzEwBPRG7OBImwSjobY1gYdjEVqxhSmSCdaqgI+Fh5+bggnHRABACaqtrY2wsBqR4GpfZc8GiBDwEDdeE4mxg5iCSHZlxMYZ3JFgJyDqMb3DOGiQGSaVESWHcGtEPe0lXrwa1CWMpFb0jiYDcCuPGrQEaAgOb6NrD0YqGotZkNWEOxoSRMIsY8u0plGCgqMNWrEKxqLrifB4LY7bWE9ZqZNjMOiAV06pcs6YaTRg/lMkN3kftPLVt9qg1pjYfHhVjagvXEUSnNsa8KTy5veBN4clN2kbtPLXV1U3hyQ2BRhWc2lJlBNGpbSlGD2Vq4f7R455a+nwE0akFo0c5Ty2bOyrz1MKjo6abWqxxDNGJlepG7Ty11tdN4ckVlG4KT65DM4Lo1EoeI7WaWh9hZJGmosxHeJ6K0x1hYyracfQEp2LCRk03FVVzy3x9PDJhLDwxd3v0tpqa/Tpquqk5gzeFJ2dOjco8NfdkBNGp8fpRzlODlSO1mhruGUF0qhN91BpTXZGjnKc6c0bgn3KRR0035Wi8en5OyGTJq+Vy3ejY+uj4bN7I2T/a6d+b17C793x2Qdoa67sQuhCf/+dtXb3/Z11UXi9XuzvzK2J4OCTvfHDpd4vmEA03uTif8/DD5jbr1dva5K9SVrW5UFz/dbw+2h1dfpWpruj14Imcl+ftcDjnxjLX9fuL079dSAx1uJSeN25aT+S7gTpfZTykL1ez3UVdz45bfuZ5+3pxTVPni3ryen3Ufn3yZG/2y2yQO09swlc5t9O/Lupw+Jf3P7TML69+efyq3WC45mz5dsX1++Yp3tuGXw2e4s7syezW5eeno2a5ym2ux6uzy3tvatYuuE5d1TfLnzYP8tfxk7izkfcGL2ZD5hvdv4Pp/xfWoDXr</script> <treescope-run-here><script type=\"application/octet-stream\"> const root = ( Array.from(document.getElementsByClassName( \"treescope_out_9b2ee383cbd84a908bc3606a4543ce35\")) .filter((elt) => !elt.dataset['step1']) )[0]; root.dataset['step1'] = 1; root.defns.insertContent( this.parentNode.querySelector('script[type=\"application/octet-stream\"]'), true ); this.parentNode.remove(); </script></treescope-run-here> </div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -703,7 +703,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training 🚀 |████████████████████████████████████████| 5000/5000 [100%] in 45.6s\n"
+      "Training 🚀 |████████████████████████████████████████| 5000/5000 [100%] in 44.7s\n"
      ]
     }
    ],
@@ -747,7 +747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "cd2305f9",
    "metadata": {},
    "outputs": [],
@@ -755,24 +755,26 @@
     "import tempfile\n",
     "from pathlib import Path\n",
     "\n",
-    "tmpdir = tempfile.TemporaryDirectory()\n",
-    "model_path = Path(tmpdir.name)\n",
     "\n",
-    "# Create the path with parents if not existed already\n",
-    "model_path.mkdir(parents=True, exist_ok=True)\n",
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
     "\n",
-    "model_state = sq.model.ModelData(\n",
-    "    params=model_params,\n",
-    "    config={\n",
-    "        \"hidden_sizes_1\": model.hidden_sizes_1,\n",
-    "        \"hidden_sizes_2\": model.hidden_sizes_1,\n",
-    "    },\n",
-    ")\n",
-    "# Save with,\n",
-    "model_state.to_file(model_path / \"model.json\")\n",
-    "# and load it back using,\n",
-    "model_state_from_file = sq.model.ModelData.from_file(model_path / \"model.json\")\n",
-    "tmpdir.cleanup()\n"
+    "    model_path = Path(tmpdir)\n",
+    "\n",
+    "    # Create the path with parents if not existed already\n",
+    "    model_path.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "    model_state = sq.model.ModelData(\n",
+    "        params=model_params,\n",
+    "        config={\n",
+    "            \"hidden_sizes_1\": model.hidden_sizes_1,\n",
+    "            \"hidden_sizes_2\": model.hidden_sizes_1,\n",
+    "        },\n",
+    "    )\n",
+    "\n",
+    "    # Save with,\n",
+    "    model_state.to_file(model_path / \"model.json\")\n",
+    "    # and load it back using,\n",
+    "    model_state_from_file = sq.model.ModelData.from_file(model_path / \"model.json\")\n"
    ]
   },
   {
@@ -785,7 +787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "5c369c4c",
    "metadata": {},
    "outputs": [
@@ -795,7 +797,7 @@
        "True"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -806,7 +808,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "0f7e2064",
    "metadata": {},
    "outputs": [
@@ -872,7 +874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "4030f3a3",
    "metadata": {},
    "outputs": [],
@@ -896,7 +898,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "d8d56af8",
    "metadata": {},
    "outputs": [
@@ -909,7 +911,7 @@
        "       -0.24955875,  0.96738053, -0.96738053], dtype=float64)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -933,7 +935,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "1892452f",
    "metadata": {},
    "outputs": [
@@ -946,7 +948,7 @@
        "       -0.24955875,  0.96738053, -0.96738053], dtype=float64)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -973,7 +975,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "cd753abc",
    "metadata": {},
    "outputs": [
@@ -983,7 +985,7 @@
        "(Array(0.06409491, dtype=float64), {'AGF': Array(0.74683027, dtype=float64)})"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1013,7 +1015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "facd3930",
    "metadata": {},
    "outputs": [
@@ -1021,7 +1023,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "|████████████████████████████████████████| 1000/1000 [100%] in 2:09.4 (7.73/s)  \n"
+      "|████████████████████████████████████████| 1000/1000 [100%] in 2:03.5 (8.09/s)  \n"
      ]
     }
    ],
@@ -1043,17 +1045,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 24,
    "id": "59647b1b",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Array([1.93835769, 0.05089961], dtype=float64)"
+       "Array([6.28318531, 5.        ], dtype=float64)"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1064,18 +1066,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 25,
    "id": "256fd30a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'AGF': Array(0.97483661, dtype=float64),\n",
-       " 'params': Array([1.93835769, 0.05089961], dtype=float64)}"
+       "{'AGF': Array(0.70075917, dtype=float64),\n",
+       " 'params': Array([6.28318531, 5.        ], dtype=float64)}"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1096,7 +1098,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 26,
    "id": "81df52f8",
    "metadata": {},
    "outputs": [],
@@ -1111,17 +1113,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 27,
    "id": "2fa3d453",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Array(0.97310763, dtype=float64)"
+       "Array(0.68582795, dtype=float64)"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
### TL;DR

Fixed the `unitary_to_expvals` function to properly broadcast operators and added a new function to generate static prediction functions.

### How to test?

1. Run the tutorial notebook to verify the changes work correctly
2. Test the `unitary_to_expvals` function with different shaped unitary matrices
3. Test the new `make_get_predict_expectation_value_fn` function by creating a static prediction function and comparing its output with the original function

### Why make this change?

1. The broadcasting fix in `unitary_to_expvals` ensures proper shape matching between operators and unitaries, preventing shape mismatch errors
2. The new `make_get_predict_expectation_value_fn` function allows for creating static prediction functions with fixed expectation values, improving performance for repeated predictions
3. Using a context manager for temporary directory handling in the tutorial ensures proper cleanup of resources