### PR TITLE
refactor: covert chex ArrayTree to optax 0.28 compat

### DIFF
--- a/src/inspeqtor/v1/boed.py
+++ b/src/inspeqtor/v1/boed.py
@@ -1,14 +1,15 @@
 import jax
 import jax.numpy as jnp
 import numpyro
-from numpyro import handlers, plate_stack  # type: ignore
+from numpyro import handlers, plate_stack
 from numpyro import distributions as dist
 
-import optax  # type: ignore
+import optax
 import typing
 import jaxtyping
-import chex
 from .decorator import warn_not_tested_function
+
+from .ctyping import ArrayTree
 
 
 def safe_shape(a: typing.Any) -> tuple[int, ...] | str:
@@ -128,7 +129,7 @@ def marginal_loss(
     target_labels: list[str],
     num_particles: int,
     evaluation: bool = False,
-) -> typing.Callable[[chex.ArrayTree, jnp.ndarray], tuple[jnp.ndarray, AuxEntry]]:
+) -> typing.Callable[[ArrayTree, jnp.ndarray], tuple[jnp.ndarray, AuxEntry]]:
     """The marginal loss implemented following
     https://docs.pyro.ai/en/dev/contrib.oed.html#pyro.contrib.oed.eig.marginal_eig
 
@@ -209,7 +210,7 @@ def vnmc_eig_loss(
     target_labels: list[str],
     num_particles: tuple[int, int],
     evaluation: bool = False,
-) -> typing.Callable[[chex.ArrayTree, jnp.ndarray], tuple[jnp.ndarray, AuxEntry]]:
+) -> typing.Callable[[ArrayTree, jnp.ndarray], tuple[jnp.ndarray, AuxEntry]]:
     """The VNMC loss implemented following
     https://docs.pyro.ai/en/dev/_modules/pyro/contrib/oed/eig.html#vnmc_eig
 
@@ -325,7 +326,7 @@ def init_params_from_guide(
     *args,
     key: jnp.ndarray,
     design: jnp.ndarray,
-) -> chex.ArrayTree:
+) -> ArrayTree:
     """Initlalize parameters of marginal guide.
 
     Args:
@@ -359,26 +360,24 @@ class HistoryEntry(typing.NamedTuple):
 
 
 def opt_eig_ape_loss(
-    loss_fn: typing.Callable[
-        [chex.ArrayTree, jnp.ndarray], tuple[jnp.ndarray, AuxEntry]
-    ],
-    params: chex.ArrayTree,
+    loss_fn: typing.Callable[[ArrayTree, jnp.ndarray], tuple[jnp.ndarray, AuxEntry]],
+    params: ArrayTree,
     num_steps: int,
     optim: optax.GradientTransformation,
     key: jnp.ndarray,
     callbacks: list = [],
-) -> chex.ArrayTree:
+) -> ArrayTree:
     """Optimize the EIG loss function.
 
     Args:
-        loss_fn (typing.Callable[[chex.ArrayTree, jnp.ndarray], tuple[jnp.ndarray, AuxEntry]]): Loss function
-        params (chex.ArrayTree): Initial parameter
+        loss_fn (typing.Callable[[ArrayTree, jnp.ndarray], tuple[jnp.ndarray, AuxEntry]]): Loss function
+        params (ArrayTree): Initial parameter
         num_steps (int): Number of optimization step
         optim (optax.GradientTransformation): Optax Optimizer
         key (jnp.ndarray): Random key
 
     Returns:
-        tuple[chex.ArrayTree, list[typing.Any]]: Optimized parameters, and optimization history.
+        tuple[ArrayTree, list[typing.Any]]: Optimized parameters, and optimization history.
     """
     # Initialize the optimizer
     opt_state = optim.init(params)

--- a/src/inspeqtor/v1/ctyping.py
+++ b/src/inspeqtor/v1/ctyping.py
@@ -1,9 +1,15 @@
 import typing
 import jax.numpy as jnp
 from flax.typing import FrozenVariableDict
-
+import jax
 
 ParametersDictType = dict[str, typing.Union[float, jnp.ndarray]]
 HamiltonianArgs = typing.TypeVar("HamiltonianArgs")
 
 Wos = typing.Any | tuple[typing.Any, FrozenVariableDict | dict[str, typing.Any]]
+
+ArrayTree = typing.Union[
+    jax.typing.ArrayLike,
+    typing.Iterable["ArrayTree"],
+    typing.Mapping[typing.Any, "ArrayTree"],
+]

--- a/src/inspeqtor/v1/optimize.py
+++ b/src/inspeqtor/v1/optimize.py
@@ -1,8 +1,8 @@
 import typing
 import jax
 import jax.numpy as jnp
-import optax  # type: ignore
-import chex
+import optax
+from .ctyping import ArrayTree
 
 
 def get_default_optimizer(n_iterations: int) -> optax.GradientTransformation:
@@ -26,26 +26,26 @@ def get_default_optimizer(n_iterations: int) -> optax.GradientTransformation:
 
 
 def minimize(
-    params: chex.ArrayTree,
+    params: ArrayTree,
     func: typing.Callable[[jnp.ndarray], tuple[jnp.ndarray, typing.Any]],
     optimizer: optax.GradientTransformation,
-    lower: chex.ArrayTree | None = None,
-    upper: chex.ArrayTree | None = None,
+    lower: ArrayTree | None = None,
+    upper: ArrayTree | None = None,
     maxiter: int = 1000,
     callbacks: list[typing.Callable] = [],
-) -> tuple[chex.ArrayTree, list[typing.Any]]:
+) -> tuple[ArrayTree, list[typing.Any]]:
     """Optimize the loss function with bounded parameters.
 
     Args:
-        params (chex.ArrayTree): Intiial parameters to be optimized
-        lower (chex.ArrayTree): Lower bound of the parameters
-        upper (chex.ArrayTree): Upper bound of the parameters
+        params (ArrayTree): Intiial parameters to be optimized
+        lower (ArrayTree): Lower bound of the parameters
+        upper (ArrayTree): Upper bound of the parameters
         func (typing.Callable[[jnp.ndarray], tuple[jnp.ndarray, typing.Any]]): Loss function
         optimizer (optax.GradientTransformation): Instance of optax optimizer
         maxiter (int, optional): Number of optimization step. Defaults to 1000.
 
     Returns:
-        tuple[chex.ArrayTree, list[typing.Any]]: Tuple of parameters and optimization history
+        tuple[ArrayTree, list[typing.Any]]: Tuple of parameters and optimization history
     """
     opt_state = optimizer.init(params)
     history = []
@@ -71,26 +71,26 @@ def minimize(
 
 def stochastic_minimize(
     key: jnp.ndarray,
-    params: chex.ArrayTree,
+    params: ArrayTree,
     func: typing.Callable[[jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, typing.Any]],
     optimizer: optax.GradientTransformation,
-    lower: chex.ArrayTree | None = None,
-    upper: chex.ArrayTree | None = None,
+    lower: ArrayTree | None = None,
+    upper: ArrayTree | None = None,
     maxiter: int = 1000,
     callbacks: list[typing.Callable] = [],
-) -> tuple[chex.ArrayTree, list[typing.Any]]:
+) -> tuple[ArrayTree, list[typing.Any]]:
     """Optimize the loss function with bounded parameters.
 
     Args:
-        params (chex.ArrayTree): Intiial parameters to be optimized
-        lower (chex.ArrayTree): Lower bound of the parameters
-        upper (chex.ArrayTree): Upper bound of the parameters
+        params (ArrayTree): Intiial parameters to be optimized
+        lower (ArrayTree): Lower bound of the parameters
+        upper (ArrayTree): Upper bound of the parameters
         func (typing.Callable[[jnp.ndarray], tuple[jnp.ndarray, typing.Any]]): Loss function
         optimizer (optax.GradientTransformation): Instance of optax optimizer
         maxiter (int, optional): Number of optimization step. Defaults to 1000.
 
     Returns:
-        tuple[chex.ArrayTree, list[typing.Any]]: Tuple of parameters and optimization history
+        tuple[ArrayTree, list[typing.Any]]: Tuple of parameters and optimization history
     """
     opt_state = optimizer.init(params)
     history = []

--- a/uv.lock
+++ b/uv.lock
@@ -2360,18 +2360,17 @@ wheels = [
 
 [[package]]
 name = "optax"
-version = "0.2.6"
+version = "0.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
-    { name = "chex" },
     { name = "jax" },
     { name = "jaxlib" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/3b/90c11f740a3538200b61cd2b7d9346959cb9e31e0bdea3d2f886b7262203/optax-0.2.6.tar.gz", hash = "sha256:ba8d1e12678eba2657484d6feeca4fb281b8066bdfd5efbfc0f41b87663109c0", size = 269660, upload-time = "2025-09-15T22:41:24.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/f9/e3d11ae6f298ee941a0690e353a323d158ba5dedc436e75621c310845c5c/optax-0.2.8.tar.gz", hash = "sha256:5b225b35066fc3eebaa4d798f1b4173b4d57d1a480610908981f8343b50af0b0", size = 301193, upload-time = "2026-03-20T23:30:05.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/ec/19c6cc6064c7fc8f0cd6d5b37c4747849e66040c6ca98f86565efc2c227c/optax-0.2.6-py3-none-any.whl", hash = "sha256:f875251a5ab20f179d4be57478354e8e21963373b10f9c3b762b94dcb8c36d91", size = 367782, upload-time = "2025-09-15T22:41:22.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/69/6a93d8600c339d7687a05857c7907bd4dd8cf88691a5ea106d7a50af90a1/optax-0.2.8-py3-none-any.whl", hash = "sha256:e3ca2d36c99daab1800ae9dbc0545034382d6bc780b24d969e1b0df65fa31cb4", size = 402960, upload-time = "2026-03-20T23:30:03.886Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### TL;DR

Replace `chex.ArrayTree` with a locally defined `ArrayTree` type.

### What changed?

A new `ArrayTree` type alias has been defined in `ctyping.py` using `jax.typing.ArrayLike` and standard `typing` constructs. All usages of `chex.ArrayTree` across `boed.py` and `optimize.py` have been replaced with this new `ArrayTree` type. Additionally, `optax` has been upgraded from `0.2.6` to `0.2.8`, which itself no longer depends on `chex`.