### PR TITLE
fix: change test command in check.bash

### DIFF
--- a/bin/check.bash
+++ b/bin/check.bash
@@ -81,7 +81,7 @@ uv run pyright src/inspeqtor
 if [[ ${INSPEQTOR_SKIP_TESTS} == false ]]; then
   stdmsg "Running test suite for all supported Python versions"
   while IFS='' read -r version; do
-    uv run --python "${version}" --isolated --with-editable '.[test]' pytest tests/.
+    uv run --python "${version}" --isolated --group test pytest tests/.
   done <<EOF
 3.13
 3.12


### PR DESCRIPTION
### TL;DR

Switch test dependency installation to use UV's dependency groups instead of extras.

### What changed?

The test runner command in `check.bash` now uses `--group test` instead of `--with-editable '.[test]'` when invoking pytest across supported Python versions